### PR TITLE
server-core - support for `event-service` Test Suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# server-core
+
+
+## Development w/ `npm link` (or `yarn link`)
+
+You may see the following when trying to use `npm link` and co-develop this module and one of our Apps (eg. `event_service`):
+
+```
+Duplicate "graphql" modules cannot be used at the same time since different
+versions may have different capabilities and behavior. The data from one
+version used in the function from another could produce confusing and
+spurious results.
+```
+
+Or, maybe this:
+
+```
+error TS2322: Type 'import("/Users/dfoley/src/withjoy/server-core/node_modules/@types/graphql/type/schema").GraphQLSchema' is not assignable to type 'import("/Users/dfoley/src/withjoy/event_service/node_modules/@types/graphql/type/schema").GraphQLSchema'.
+  Types of property 'getQueryType' are incompatible.
+```
+
+To fix this problem, symlink the App's `graphql` module into `service-core`;
+
+```bash
+# from the shared parent directory of both repos,
+rm -rf server-core/node_modules/graphql
+ln -s FULL/PATH/TO/event_service/node_modules/graphql server-core/node_modules
+
+rm -rf server-core/node_modules/@types/graphql
+ln -s FULL/PATH/TO/event_service/node_modules/@types/graphql server-core/node_modules/@types
+```
+
+This is because `graphql` and all of the Apollo modules need to stay in close alignment;
+that's why we've pinned to *specific versions* in `server-core` and all of the Apps that utilize it.
+You'll also see `graphql` in this module's `peerDependencies`.
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Context, IContext, createContext } from './server/apollo.context'
-import { createApolloServer } from './server/apollo.server'
+import { IApolloServerArgs, createApolloServer } from './server/apollo.server'
 import { IServer, Server } from './server/server'
 import { initApp } from './server/server.init';
 import { tokenCheck } from './authentication/token.check';
@@ -15,6 +15,7 @@ export {
   Context,
   IContext,
   createContext,
+  IApolloServerArgs,
   createApolloServer,
   IServer,
   Server,

--- a/src/middleware/body.parser.ts
+++ b/src/middleware/body.parser.ts
@@ -1,0 +1,28 @@
+import bodyParser from 'body-parser';
+import { Request, Response, NextFunction, RequestHandler } from 'express'
+
+const CONTENT_TYPE: string = 'application/graphql';
+
+// will handle the body => String part
+const bodyParserGraphqlText: RequestHandler = bodyParser.text({ type: CONTENT_TYPE });
+
+
+export function bodyParserGraphql(req: Request, res: Response, next: NextFunction): void {
+  const { headers } = req;
+  if (headers['content-type'] !== CONTENT_TYPE) {
+    // we have One Job
+    next();
+    return;
+  }
+
+  // dervied from `body-parser-graphql`
+  //   which makes 'application/json' assumptions that we *don't* want to make
+  //   @see https://github.com/graphql-middleware/body-parser-graphql
+  bodyParserGraphqlText(req, res, () => {
+    headers['content-type'] = 'application/json';
+    req.body = {
+      query: req.body,
+    };
+    next();
+  });
+}

--- a/src/server/apollo.server.ts
+++ b/src/server/apollo.server.ts
@@ -1,11 +1,11 @@
 import { ApolloServer } from 'apollo-server-express';
 import { Config } from 'apollo-server';
 
-interface ApolloServerArgs extends Config {
+export interface IApolloServerArgs extends Config {
   contextFunc?: (ctx: any) => any;
 }
 
-export const createApolloServer = (args: ApolloServerArgs) => {
+export const createApolloServer = (args: IApolloServerArgs) => {
   const server = new ApolloServer({
     ...args,
     context: (ctx: any) => {


### PR DESCRIPTION
- expose Server#app, IApolloServerArgs for use by `supertest`
- use 'error' listeners during Server#start and #stop
- implement 'Content-Type: application/graphql' support