### PR TITLE
server-core - support for both REST and GraphQL Error logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist/**/*"
   ],
   "scripts": {
-    "prebuild": "rm -r ./dist",
+    "prebuild": "rm -rf ./dist",
     "build": "tsc",
     "test": "NODE_ENV=test jest --detectOpenHandles --no-cache --forceExit --config jest.config.js",
     "gentype": "apollo client:codegen --endpoint=http://localhost:9091/graphql --target=typescript --includes=src/**/*.ts --outputFlat=src/graphql/types.ts",
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "jest": "24.1.0",
+    "node-mocks-http": "^1.7.3",
     "ts-jest": "23.10.5",
     "typemoq": "2.1.0"
   }

--- a/src/authentication/token.check.ts
+++ b/src/authentication/token.check.ts
@@ -10,7 +10,7 @@ export const tokenCheck = (tokenConfig: TokenConfig) => async (req: Request, res
     if (decoded instanceof Error) {
       next();
     } else {
-      req.token = token;
+      (req as any).token = token;
       next();
     }
   } else {

--- a/src/middleware/error.logging.spec.ts
+++ b/src/middleware/error.logging.spec.ts
@@ -1,0 +1,269 @@
+import 'jest';
+import * as TypeMoq from 'typemoq';
+import { createRequest, createResponse, Headers } from 'node-mocks-http';
+import { Request, Response, NextFunction } from 'express';
+import { Console } from 'console';
+import { GraphQLError } from 'graphql';
+
+import {
+  errorLoggingExpress,
+  errorFormattingApollo,
+} from './error.logging';
+
+
+describe('error.logging', () => {
+  let consoleMock: TypeMoq.IGlobalMock<Console>;
+
+  beforeEach(() => {
+    consoleMock = TypeMoq.GlobalMock.ofInstance<Console>(console, 'console', global);
+  });
+
+
+  describe('errorLoggingExpress', () => {
+    let err: Error;
+    let req: Request;
+    let res: Response;
+    let nextMock: TypeMoq.IMock<NextFunction>;
+
+    beforeEach(() => {
+      err = new Error('BOOM');
+      err.stack = 'STACK'; // for reproducibility
+
+      req = createRequest({
+        path: '/path',
+        params: { params: true },
+        query: { query: true },
+        body: { body: true },
+      });
+      res = createResponse();
+      nextMock = TypeMoq.Mock.ofType<NextFunction>();
+    });
+
+
+    it('logs an Error', () => {
+      TypeMoq.GlobalScope.using(consoleMock).with(() => {
+        errorLoggingExpress(err, req, res, nextMock.object);
+      });
+
+      consoleMock.verify(
+        (mocked) => mocked.error(JSON.stringify({
+          error: {
+            message: 'BOOM',
+            name: 'Error',
+            stack: 'STACK',
+          },
+          request: {
+            path: '/path',
+            params: { params: true },
+            query: { query: true },
+            body: { body: true },
+          },
+        })),
+        TypeMoq.Times.exactly(1)
+      );
+    });
+
+    it('responds with an Error', () => {
+      TypeMoq.GlobalScope.using(consoleMock).with(() => {
+        errorLoggingExpress(err, req, res, nextMock.object);
+      });
+
+      expect(res.headersSent).toBe(true);
+      expect((res as any)._getStatusCode()).toBe(500);
+      expect((res as any)._isJSON()).toEqual(true);
+      expect(JSON.parse((res as any)._getData())).toMatchObject({
+        error: {
+          message: 'BOOM',
+          name: 'Error',
+        },
+      });
+    });
+
+    it('handles the Error', () => {
+      TypeMoq.GlobalScope.using(consoleMock).with(() => {
+        errorLoggingExpress(err, req, res, nextMock.object);
+      });
+
+      nextMock.verify(
+        (mock) => mock(),
+        TypeMoq.Times.never()
+      );
+    });
+
+
+    it('does no handling without an Error', () => {
+      TypeMoq.GlobalScope.using(consoleMock).with(() => {
+        errorLoggingExpress((null as unknown), req, res, nextMock.object);
+      });
+
+      nextMock.verify(
+        (mock) => mock(),
+        TypeMoq.Times.exactly(1)
+      );
+
+      consoleMock.verify(
+        (mocked) => mocked.error(TypeMoq.It.isAnyString()),
+        TypeMoq.Times.never()
+      );
+
+      expect(res.headersSent).toBe(false);
+    });
+
+    it('respects additional Error properties, when available', () => {
+      err.name = 'ForbiddenError';
+      (err as any).statusCode = 403;
+      (err as any).code = 'FORBIDDEN_ERROR';
+
+      TypeMoq.GlobalScope.using(consoleMock).with(() => {
+        errorLoggingExpress(err, req, res, nextMock.object);
+      });
+
+      consoleMock.verify(
+        (mocked) => mocked.error(JSON.stringify({
+          error: {
+            message: 'BOOM',
+            name: 'ForbiddenError',
+            code: 'FORBIDDEN_ERROR',
+            statusCode: 403,
+            stack: 'STACK',
+          },
+          request: {
+            path: '/path',
+            params: { params: true },
+            query: { query: true },
+            body: { body: true },
+          },
+        })),
+        TypeMoq.Times.exactly(1)
+      );
+
+      expect(res.headersSent).toBe(true);
+      expect((res as any)._getStatusCode()).toBe(403);
+      expect((res as any)._isJSON()).toEqual(true);
+      expect(JSON.parse((res as any)._getData())).toMatchObject({
+        error: {
+            message: 'BOOM',
+            name: 'ForbiddenError',
+            code: 'FORBIDDEN_ERROR',
+            statusCode: 403,
+        },
+      });
+    });
+
+    it('is very selective about Request properties', () => {
+      req = createRequest({
+        protocol: 'IGNORED',
+        host: 'IGNORED',
+        hostname: 'IGNORED',
+        headers: ({ ignored: 'yes' } as Headers),
+
+        path: '/path',
+        params: { params: true },
+        query: { query: true },
+        body: { body: true },
+      });
+
+      TypeMoq.GlobalScope.using(consoleMock).with(() => {
+        errorLoggingExpress(err, req, res, nextMock.object);
+      });
+
+      consoleMock.verify(
+        (mocked) => mocked.error(JSON.stringify({
+          error: {
+            message: 'BOOM',
+            name: 'Error',
+            stack: 'STACK',
+          },
+          request: {
+            path: '/path',
+            params: { params: true },
+            query: { query: true },
+            body: { body: true },
+          },
+        })),
+        TypeMoq.Times.exactly(1)
+      );
+    });
+  });
+
+
+  describe('errorFormattingApollo', () => {
+    let enrichedError: any;
+
+    it('logs an Error', () => {
+      enrichedError = {
+        message: 'BOOM',
+        name: 'ENRICHED_ERROR',
+        locations: [
+          {
+            line: 23,
+            column: 5,
+          },
+        ],
+        path: [
+          'boom'
+        ],
+        extensions: {
+          code: 'INTERNAL_SERVER_ERROR',
+          exception: {
+            stacktrace: [
+              'Error: BOOM',
+              '    STACK',
+            ],
+          },
+        },
+      }
+
+      let returned;
+      TypeMoq.GlobalScope.using(consoleMock).with(() => {
+        returned = errorFormattingApollo(enrichedError);
+      });
+
+      consoleMock.verify(
+        (mocked) => mocked.error(JSON.stringify({
+          error: {
+            message: 'BOOM',
+            name: 'ENRICHED_ERROR',
+            code: 'INTERNAL_SERVER_ERROR',
+            stack: 'Error: BOOM\n    STACK',
+          },
+        })),
+        TypeMoq.Times.exactly(1)
+      );
+
+      expect(returned).toBe(enrichedError);
+    });
+
+    it('logs an unexpected Object', () => {
+      enrichedError = Object.create(null);
+
+      let returned;
+      TypeMoq.GlobalScope.using(consoleMock).with(() => {
+        returned = errorFormattingApollo(enrichedError);
+      });
+
+      consoleMock.verify(
+        (mocked) => mocked.error(JSON.stringify({
+          error: {},
+        })),
+        TypeMoq.Times.exactly(1)
+      );
+
+      expect(returned).toBe(enrichedError);
+    });
+
+    it('does no handling without an Error', () => {
+      let returned;
+      TypeMoq.GlobalScope.using(consoleMock).with(() => {
+        returned = errorFormattingApollo(null);
+      });
+
+      consoleMock.verify(
+        (mocked) => mocked.error(TypeMoq.It.isAnyString()),
+        TypeMoq.Times.never()
+      );
+
+      expect(returned).toBe(null);
+    });
+  });
+});

--- a/src/middleware/error.logging.ts
+++ b/src/middleware/error.logging.ts
@@ -1,0 +1,87 @@
+import urlLib from 'url';
+import {
+  isError,
+  pick,
+  get,
+} from 'lodash';
+import {
+  Request,
+  Response,
+  NextFunction,
+  ErrorRequestHandler,
+} from 'express'
+
+
+export const errorLoggingExpress: ErrorRequestHandler = function errorLoggingExpress(
+  err: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (! err) {
+    // this is someone else's job
+    next();
+    return;
+  }
+
+  // what was requested
+  const requested = pick(req, 'path', 'params', 'query', 'body');
+
+  const { statusCode, code } = (err as any); // "Property 'FOO' does not exist on type 'Error'."
+  let responded: object;
+  let logged: object;
+
+  if (isError(err)) {
+    // how we respond
+    const { message, name, stack } = err;
+    responded = { message, name, code, statusCode };
+
+    // what we log
+    logged = {
+      ...responded,
+      stack,
+    };
+  }
+  else {
+    responded = {
+      message: String(err),
+    };
+    logged = responded;
+  }
+
+  console.error(JSON.stringify({
+    error: logged,
+    request: requested,
+  }));
+
+  // we handle the response
+  res.status(statusCode || 500).json({
+    error: responded,
+  });
+}
+
+/**
+ * "enrichedError" is from private `enrichError` in `apollo-server-errors`
+ *   @see https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-errors/src/index.ts#L39-L101
+ *   "follows similar structure to https://github.com/graphql/graphql-js/blob/master/src/error/GraphQLError.js#L145-L193"
+ *
+ * @see https://www.apollographql.com/docs/apollo-server/features/errors
+ */
+export function errorFormattingApollo(enrichedError: any): any {
+  if (! enrichedError) {
+    // why are we even here?
+    return enrichedError;
+  }
+console.log('---', JSON.stringify(enrichedError));
+
+  const { message, name } = enrichedError;
+  const code = get(enrichedError, 'extensions.code')
+  const stacktrace = get(enrichedError, 'extensions.exception.stacktrace');
+  const stack = (Array.isArray(stacktrace) ? stacktrace.join('\n') : stacktrace);
+  console.error(JSON.stringify({
+    error: { message, name, code, stack },
+  }));
+
+  // pass-thru, no re-formatting
+  return enrichedError;
+}

--- a/src/server/apollo.context.ts
+++ b/src/server/apollo.context.ts
@@ -36,7 +36,7 @@ export class Context implements IContext {
   private _token: string;
   private _currentUser?: UserFragment;
   private apolloLink: HttpLink;
-  
+
   constructor(token?: string, userId?: string, identityUrL?: string) {
     this._token = token ? token : 'no-token';
     this._userId = userId ? userId : 'no-user';
@@ -61,9 +61,10 @@ export class Context implements IContext {
   }
 
   public async me() {
-    return new Promise((resolve, reject, ) => {
+    return new Promise((resolve, reject) => {
       if (!this.apolloLink) {
-        reject('apollo link no instantiated');
+        reject(new Error('apollo link not instantiated'));
+        return;
       }
       execute(this.apolloLink, { query: IDENTITY_ME, context: {
         headers: {

--- a/src/server/apollo.server.ts
+++ b/src/server/apollo.server.ts
@@ -1,5 +1,6 @@
 import { ApolloServer } from 'apollo-server-express';
 import { Config } from 'apollo-server';
+import { errorFormattingApollo } from '../middleware/error.logging';
 
 export interface IApolloServerArgs extends Config {
   contextFunc?: (ctx: any) => any;
@@ -14,7 +15,8 @@ export const createApolloServer = (args: IApolloServerArgs) => {
       } else {
         return ctx;
       }
-    }
+    },
+    formatError: errorFormattingApollo,
   });
   return server;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,9 +1,10 @@
 import http from 'http';
-import express, { Request, Response, RequestHandler, Router } from 'express';
+import express, { Request, Response, RequestHandler, ErrorRequestHandler, Router } from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
 import bodyParser from 'body-parser';
 import { bodyParserGraphql } from '../middleware/body.parser';
+import { errorLoggingExpress } from '../middleware/error.logging';
 import { ApolloServer } from 'apollo-server-express';
 
 export interface IServer {
@@ -43,6 +44,7 @@ export class Server implements IServer {
       this.bootApollo(args.apollo, args.apolloMiddleware ? [ ...apolloMiddlewareArray, ...args.apolloMiddleware ] : apolloMiddlewareArray);
     }
     this.expressRoutes(args && args.routes ? [...args.routes] : []);
+    this.middleware([ errorLoggingExpress ]);
   }
 
   public init = async (port: number) => {
@@ -95,7 +97,7 @@ export class Server implements IServer {
     });
   }
 
-  private middleware(middleware: Array<RequestHandler>) {
+  private middleware(middleware: Array<RequestHandler | ErrorRequestHandler>) {
     middleware.forEach(middleware => {
       this.app.use(middleware);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,6 +446,7 @@
 "@types/node-fetch@2.1.6":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.1.6.tgz#4326288b49f352a142f03c63526ebce0f4c50877"
+  integrity sha512-Hv1jgh3pfpUEl2F2mqUd1AfLSk1YbUCeBJFaP36t7esAO617dErqdxWb5cdG2NfJGOofkmBW36fdx0dVewxDRg==
   dependencies:
     "@types/node" "*"
 
@@ -1687,7 +1688,7 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@~1.1.2:
+depd@^1.1.0, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
@@ -2097,7 +2098,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fresh@0.5.2:
+fresh@0.5.2, fresh@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
@@ -3575,7 +3576,7 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^2.0.0"
 
-merge-descriptors@1.0.1:
+merge-descriptors@1.0.1, merge-descriptors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
@@ -3589,7 +3590,7 @@ merge@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -3624,6 +3625,11 @@ mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
 mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+
+mime@^1.3.4:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -3747,6 +3753,11 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+net@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/net/-/net-1.0.2.tgz#d1757ec9a7fb2371d83cf4755ce3e27e10829388"
+  integrity sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g=
+
 netrc-parser@^3.1.4:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/netrc-parser/-/netrc-parser-3.1.6.tgz#7243c9ec850b8e805b9bdc7eae7b1450d4a96e72"
@@ -3771,6 +3782,22 @@ node-fetch@2.3.0, node-fetch@^2.1.2, node-fetch@^2.2.0:
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+
+node-mocks-http@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-mocks-http/-/node-mocks-http-1.7.3.tgz#1c744189f012c1977f4d97443495931a7cd5b4d3"
+  integrity sha512-wayzLNhEroH3lJj113pFKQ1cd1GKG1mXoZR1HcKp/o9a9lTGGgVY/hYeLajiIFr/z4tXFKOdfJickqqihBtn9g==
+  dependencies:
+    accepts "^1.3.5"
+    depd "^1.1.0"
+    fresh "^0.5.2"
+    merge-descriptors "^1.0.1"
+    methods "^1.1.2"
+    mime "^1.3.4"
+    net "^1.0.2"
+    parseurl "^1.3.1"
+    range-parser "^1.2.0"
+    type-is "^1.6.16"
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -4084,6 +4111,11 @@ parse5@^3.0.3:
   dependencies:
     "@types/node" "*"
 
+parseurl@^1.3.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
@@ -4260,7 +4292,7 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-range-parser@~1.2.0:
+range-parser@^1.2.0, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 


### PR DESCRIPTION
- new ErrorRequestHandler for express / REST calls
- Apollo `formatError` handler for "enrichedError" (vs. Error instance)
- "logging" = send a JSON payload to `console.error`
- Promise#reject should be given an Error instance, not a String
- "Property 'token' does not exist on type 'Request'."