### PR TITLE
server-core - auth never succeeding, everyone seems to be a Guest

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "typescript": "3.3.3"
   },
   "devDependencies": {
+    "@types/lolex": "^3.1.1",
     "jest": "24.1.0",
+    "lolex": "^4.0.1",
     "node-mocks-http": "^1.7.3",
     "ts-jest": "23.10.5",
     "typemoq": "2.1.0"

--- a/src/authentication/token.check.spec.ts
+++ b/src/authentication/token.check.spec.ts
@@ -1,0 +1,146 @@
+import 'jest';
+import jwt from 'jsonwebtoken';
+import * as TypeMoq from 'typemoq';
+import { createRequest } from 'node-mocks-http';
+import { Request, Response, NextFunction } from 'express';
+
+import { TokenConfig } from './verify.token';
+import {
+  deriveTokenValue,
+  tokenCheck,
+} from './token.check';
+
+
+describe('token.check', () => {
+  describe('deriveTokenValue', () => {
+    const TOKEN_VALUE = 'TOKEN_VALUE';
+
+    it('derives a Bearer token value', () => {
+      const req = createRequest({
+        headers: {
+          authorization: `Bearer ${ TOKEN_VALUE }`,
+        },
+      });
+      expect(deriveTokenValue(req)).toBe(TOKEN_VALUE);
+    });
+
+    it('returns null without an Authorization type', () => {
+      const req = createRequest({
+        headers: {
+          authorization: TOKEN_VALUE,
+        },
+      });
+      expect(deriveTokenValue(req)).toBeNull();
+    });
+
+    it('returns null without an Authorization header', () => {
+      const req = createRequest();
+      expect(deriveTokenValue(req)).toBeNull();
+    });
+  });
+
+
+  describe('tokenCheck', () => {
+    const RESPONSE: Response = (<unknown>undefined as Response); // it's ignored
+    const TOKEN_CONFIG = <TokenConfig>{
+      auth0: {
+        MATCH: {
+          options: {
+            audience: 'MATCH_AUDIENCE',
+            issuer: 'https://match.issuer.com',
+          },
+          secret: {
+            data: 'MATCH_SECRET',
+            encoding: 'base64',
+          },
+        },
+        OTHER: {
+          options: {
+            audience: 'OTHER_AUDIENCE',
+            issuer: 'https://other.issuer.com',
+          },
+          secret: {
+            data: 'OTHER_SECRET',
+            encoding: 'utf8',
+          },
+        },
+      },
+    };
+    const TOKEN_SIGNED: string = (function signedJWT(): string {
+      const { secret, options } = TOKEN_CONFIG.auth0.MATCH;
+      return jwt.sign(
+        { payload: true },
+        Buffer.from(secret.data, secret.encoding),
+        options
+      );
+    })();
+
+
+    it('returns a middleware Function', () => {
+      const middleware = tokenCheck(TOKEN_CONFIG);
+
+      expect(middleware).toBeInstanceOf(Function);
+    });
+
+    it('verifies a token value', () => {
+      const req = createRequest({
+        headers: {
+          authorization: `Bearer ${ TOKEN_SIGNED }`,
+        },
+      });
+
+      const middleware = tokenCheck(TOKEN_CONFIG);
+      const nextMock = TypeMoq.Mock.ofType<NextFunction>();
+      middleware(req, RESPONSE, nextMock.object);
+
+      nextMock.verify(
+        (mock) => mock(),
+        TypeMoq.Times.exactly(1)
+      );
+
+      // it('exposes the verified token on the Request')
+      expect(req.token).toBe(TOKEN_SIGNED);
+    });
+
+    it('fails to verify a token value', () => {
+      const req = createRequest({
+        headers: {
+          authorization: `Bearer ${ TOKEN_SIGNED }`,
+        },
+      });
+
+      const middleware = tokenCheck({
+        auth0: {
+          // no MATCH
+          OTHER: TOKEN_CONFIG.auth0.OTHER,
+        },
+      });
+      const nextMock = TypeMoq.Mock.ofType<NextFunction>();
+      middleware(req, RESPONSE, nextMock.object);
+
+      nextMock.verify(
+        (mock) => mock(),
+        TypeMoq.Times.exactly(1)
+      );
+      expect(req.token).toBeUndefined();
+    });
+
+    it('fails to verify a bad Authorization header', () => {
+      const req = createRequest({
+        headers: {
+          authorization: TOKEN_SIGNED,
+        },
+      });
+
+      const middleware = tokenCheck(TOKEN_CONFIG);
+      const nextMock = TypeMoq.Mock.ofType<NextFunction>();
+      middleware(req, RESPONSE, nextMock.object);
+
+      nextMock.verify(
+        (mock) => mock(),
+        TypeMoq.Times.exactly(1)
+      );
+      expect(req.token).toBeUndefined();
+    });
+  });
+});

--- a/src/authentication/token.check.ts
+++ b/src/authentication/token.check.ts
@@ -1,10 +1,25 @@
 import { Request, Response, NextFunction } from 'express';
 import { verifyAll, TokenConfig } from './verify.token';
 
-const getToken = (req: Request) => req.headers.authorization;
+/**
+ * Derives the token value -- usually a JWT -- from the Authorization header.
+ *
+ * eg. 'Authorization: Bearer TOKEN_VALUE' => TOKEN_VALUE
+ */
+export const deriveTokenValue = (req: Request): string | null => {
+  const header = req.headers.authorization;
+  if (! header) {
+    return null;
+  }
+  const [ tokenType, tokenValue ] = header.split(' ');
+  if (! tokenValue) {
+    return null;
+  }
+  return tokenValue;
+}
 
 export const tokenCheck = (tokenConfig: TokenConfig) => async (req: Request, res: Response, next: NextFunction) => {
-  const token = getToken(req);
+  const token = deriveTokenValue(req);
   if (token) {
     const decoded = verifyAll(tokenConfig, token);
     if (decoded instanceof Error) {

--- a/src/authentication/verify.token.spec.ts
+++ b/src/authentication/verify.token.spec.ts
@@ -1,0 +1,100 @@
+import 'jest';
+import jwt from 'jsonwebtoken';
+import lolex, { InstalledClock, NodeClock } from 'lolex';
+
+import {
+  TokenConfig,
+  verifyAll,
+} from './verify.token';
+
+
+const PAYLOAD = { payload: true };
+const EPOCH = 1234567890; // Unix epoch
+const TOKEN_CONFIG = <TokenConfig>{
+  auth0: {
+    MATCH: {
+      options: {
+        audience: 'MATCH_AUDIENCE',
+        issuer: 'https://match.issuer.com',
+      },
+      secret: {
+        data: 'MATCH_SECRET',
+        encoding: 'base64',
+      },
+    },
+    OTHER: {
+      options: {
+        audience: 'OTHER_AUDIENCE',
+        issuer: 'https://other.issuer.com',
+      },
+      secret: {
+        data: 'OTHER_SECRET',
+        encoding: 'utf8',
+      },
+    },
+  },
+};
+const TOKEN_SIGNED: string = (function signedJWT(): string {
+  const clock = lolex.install({
+    target: global,
+    now: (EPOCH * 1000), // in ms
+  });
+
+  try {
+    const { secret, options } = TOKEN_CONFIG.auth0.MATCH;
+    const token = jwt.sign(
+      PAYLOAD,
+      Buffer.from(secret.data, secret.encoding),
+      options
+    );
+    return token;
+  }
+  finally {
+    clock.uninstall();
+  }
+})();
+
+
+describe('verify.token', () => {
+  describe('verifyAll', () => {
+    it('verifies a token value', () => {
+      const result = verifyAll(TOKEN_CONFIG, TOKEN_SIGNED);
+
+      expect(result).toEqual({
+        aud: TOKEN_CONFIG.auth0.MATCH.options.audience,
+        iat: EPOCH,
+        iss: TOKEN_CONFIG.auth0.MATCH.options.issuer,
+
+        ...PAYLOAD,
+      });
+    });
+
+    it('fails with no providers', () => {
+      const result = verifyAll(<TokenConfig>{ auth0: {} }, TOKEN_SIGNED);
+
+      // it('returns an Error, rather than throwing it')
+      expect(result).toBeInstanceOf(Error);
+      expect((<Error>result).message).toMatch(/no matching provider/);
+    });
+
+    it('fails with no matching provider', () => {
+      const result = verifyAll(<TokenConfig>{
+        auth0: {
+          OTHER: TOKEN_CONFIG.auth0.OTHER,
+        },
+      }, TOKEN_SIGNED);
+
+      // it('returns an Error, rather than throwing it')
+      expect(result).toBeInstanceOf(Error);
+      expect((<Error>result).message).toMatch(/no matching provider/);
+    });
+
+    it('fails on a malformed token', () => {
+      const result = verifyAll(TOKEN_CONFIG, 'MALFORMED');
+
+      // it('returns an Error, rather than throwing it')
+      expect(result).toBeInstanceOf(Error);
+      expect((<Error>result).message).toMatch(/jwt malformed/);
+    });
+  });
+});

--- a/src/authentication/verify.token.ts
+++ b/src/authentication/verify.token.ts
@@ -28,7 +28,7 @@ interface Auth0Token {
  * the most applicable error (not "invalid signature")
  *
  * @param config
- * @param token
+ * @param token a JWT token
  * @returns Auth0Token | Error
  */
 export const verifyAll = (tokenConfig: TokenConfig, token: string) => {
@@ -50,5 +50,5 @@ export const verifyAll = (tokenConfig: TokenConfig, token: string) => {
     } else {
       return curr;
     }
-  });
+  }, new Error('no matching provider in tokenConfig'));
 };

--- a/src/server/apollo.context.ts
+++ b/src/server/apollo.context.ts
@@ -88,7 +88,11 @@ export class Context implements IContext {
             resolve();
           }
         },
-        error: (error: any) => resolve()
+        error: (err: any) => {
+          // TODO:  telemetry
+          console.error(err);
+          resolve();
+        }
       })
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -429,6 +429,11 @@
   version "4.14.120"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.120.tgz#cf265d06f6c7a710db087ed07523ab8c1a24047b"
 
+"@types/lolex@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/lolex/-/lolex-3.1.1.tgz#d40895223e5c8f8aa64f5500c6ca4eeab067d432"
+  integrity sha512-NU2qVtKxbt4IBvjEOW1QeUnV6KGUF6hpgJyvwZt3JrXe2qmwQF0+BiazQw+iFy9qL5ie+QHOxTzXkcvJUEh76g==
+
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
@@ -3484,6 +3489,11 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
+
+lolex@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.0.1.tgz#4a99c2251579d693c6a083446dae0e5c3844d3fa"
+  integrity sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw==
 
 long@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- extract ID Token from the 'Authorization' header, removing "Bearer " prefix
- error logging upon `identity_service` request failure

## version: PATCH

i think we can get away with just a PATCH on this change