### PR TITLE
Jun19/encode for firebase key

### DIFF
--- a/src/authentication/token.check.spec.ts
+++ b/src/authentication/token.check.spec.ts
@@ -59,7 +59,7 @@ describe('token.check', () => {
 
 
   describe('tokenCheck', () => {
-    const RESPONSE: Response = (<unknown>undefined as Response); // it's ignored
+    const RESPONSE: Response = (<any>undefined as Response); // it's ignored
     const TOKEN_CONFIG = <TokenConfig>{
       auth0: {
         MATCH: {
@@ -88,7 +88,7 @@ describe('token.check', () => {
       const { secret, options } = TOKEN_CONFIG.auth0.MATCH;
       return jwt.sign(
         { payload: true },
-        Buffer.from(secret.data, secret.encoding),
+        Buffer.from(secret.data, secret.encoding as any),
         options
       );
     })();

--- a/src/authentication/verify.token.spec.ts
+++ b/src/authentication/verify.token.spec.ts
@@ -44,7 +44,7 @@ const TOKEN_SIGNED: string = (function signedJWT(): string {
     const { secret, options } = TOKEN_CONFIG.auth0.MATCH;
     const token = jwt.sign(
       PAYLOAD,
-      Buffer.from(secret.data, secret.encoding),
+      Buffer.from(secret.data, secret.encoding as any),
       options
     );
     return token;

--- a/src/authentication/verify.token.ts
+++ b/src/authentication/verify.token.ts
@@ -35,7 +35,7 @@ export const verifyAll = (tokenConfig: TokenConfig, token: string) => {
   return Object.keys(tokenConfig.auth0).map(key => {
     try {
       const secretObj = tokenConfig.auth0[key].secret;
-      const buffer = Buffer.from(secretObj.data, secretObj.encoding);
+      const buffer = Buffer.from(secretObj.data, secretObj.encoding as any);
       return jwt.verify(token, buffer, tokenConfig.auth0[key].options) as Auth0Token;
     } catch (err) {
       return err as Error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { EntityModelTemplate, ModelTemplate } from './templates/model.template';
 import { Template } from './templates/entity.template';
 import { createGraphQLEnumValues } from './utils/graphql.enum';
 import { EdgeWrapper, edgeWrapperType } from './utils/edge.wrapper';
+import encodeForFirebaseKey from './utils/encodeForFirebaseKey';
 
 export {
   Context,
@@ -45,5 +46,6 @@ export {
   AuthorizationError,
   BadRequestError,
   GenericError,
-  NotFoundError
+  NotFoundError,
+  encodeForFirebaseKey
 }

--- a/src/utils/encodeForFirebaseKey.spec.ts
+++ b/src/utils/encodeForFirebaseKey.spec.ts
@@ -1,0 +1,36 @@
+import 'jest';
+import {encode, decode} from './encodeForFirebaseKey';
+
+describe('encodeForFirebaseKey', () => {
+
+  it('actually alters the input string', () => {
+    const TEST_STRING = "$ $$ $>.4..4 4.4.$### 3j#//l[p[p[[[p[p[[][]/a//a/asfdkjasdfjasio3####$$$>.4....4..[][$";
+    const theyAreDifferent = TEST_STRING !== encode(TEST_STRING);
+    expect(theyAreDifferent).toBe(true);
+  })
+
+  it('provides an encode and decode operation that are inverses of each other', () => {
+    const TEST_STRING = "$ $$ $>.4..4 4.4.$### 3j#//l[p[p[[[p[p[[][]/a//a/asfdkjasdfjasio3####$$$>.4....4..[][$";
+    expect(TEST_STRING).toBe(decode(encode(TEST_STRING)));
+  });
+
+  it('provides idempotent encode and decode operations', () => {
+    const TEST_STRING = "$ $$ $>.4..4 4.4.$### 3j#//l[p[p[[[p[p[[][]/a//a/asfdkjasdfjasio3####$$$>.4....4..[][$";
+    const once = encode(TEST_STRING);
+    const thrice = encode(encode(encode(TEST_STRING)));
+    expect(once).toBe(thrice);
+    expect(once).not.toBe(TEST_STRING);
+    const onceMore = decode(thrice);
+    const thriceMore = decode(decode(decode(once)));
+    expect(onceMore).toBe(TEST_STRING);
+    expect(thriceMore).toBe(TEST_STRING);
+  });
+
+  it('encodes and decodes a specific example', () => {
+    const ENCODED = "%24%5B%5D%23%2F!!!%2E";
+    const SWEAR_WORD = "$[]#/!!!.";
+    expect(ENCODED).toBe(encode(SWEAR_WORD));
+    expect(SWEAR_WORD).toBe(decode(ENCODED));
+  })
+
+});

--- a/src/utils/encodeForFirebaseKey.spec.ts
+++ b/src/utils/encodeForFirebaseKey.spec.ts
@@ -5,8 +5,7 @@ describe('encodeForFirebaseKey', () => {
 
   it('actually alters the input string', () => {
     const TEST_STRING = "$ $$ $>.4..4 4.4.$### 3j#//l[p[p[[[p[p[[][]/a//a/asfdkjasdfjasio3####$$$>.4....4..[][$";
-    const theyAreDifferent = TEST_STRING !== encode(TEST_STRING);
-    expect(theyAreDifferent).toBe(true);
+    expect(TEST_STRING).not.toBe(encode(TEST_STRING));
   })
 
   it('provides an encode and decode operation that are inverses of each other', () => {

--- a/src/utils/encodeForFirebaseKey.ts
+++ b/src/utils/encodeForFirebaseKey.ts
@@ -1,0 +1,32 @@
+
+type encodingMap = {
+  re: RegExp,
+  val: string
+}
+
+const forward: encodingMap[] = [
+    {re: /\./g,   val:    "%2E"},                     // "."
+    {re: /\$/g,   val:    encodeURIComponent("$")},   // "$"
+    {re: /\[/g,   val:    encodeURIComponent("[")},   // "["
+    {re: /\]/g,   val:    encodeURIComponent("]")},   // "]"
+    {re: /\#/g,   val:    encodeURIComponent("#")},   // "#"
+    {re: /\//g,   val:    encodeURIComponent("/")}    // "/"
+];
+
+const backward: encodingMap[] = [
+  { re: new RegExp("%2E", 'g')                  , val: '.' } ,
+  { re: new RegExp(encodeURIComponent("$"), 'g'), val: '$' } ,
+  { re: new RegExp(encodeURIComponent("["), 'g'), val: '[' } ,
+  { re: new RegExp(encodeURIComponent("]"), 'g'), val: ']' } ,
+  { re: new RegExp(encodeURIComponent("#"), 'g'), val: '#' } ,
+  { re: new RegExp(encodeURIComponent("/"), 'g'), val: '/' }
+];
+
+const transform = (mapping: encodingMap[]) => (str: string): string =>
+  mapping.reduce(
+    (str, {re, val}) => str.replace(re, val),
+    str
+  )
+
+export const encode = transform(forward);
+export const decode = transform(backward);

--- a/src/utils/encodeForFirebaseKey.ts
+++ b/src/utils/encodeForFirebaseKey.ts
@@ -30,3 +30,8 @@ const transform = (mapping: encodingMap[]) => (str: string): string =>
 
 export const encode = transform(forward);
 export const decode = transform(backward);
+
+export default {
+  encode,
+  decode
+};


### PR DESCRIPTION
`adds the classic encodeForFirebaseKey and a test to prove it works properly`

which is frequently use to encode things used as keys in firebase to remove dangerous characters (eg '.')

See :

https://bitbucket.org/joylife/joy/src/71be8ceae34e146cfe5b7d881b5a5ed5ff287e65/modules/mandrill_dal/mandrillManager.js?at=develop#mandrillManager.js-13

https://bitbucket.org/joylife/joy/src/71be8ceae34e146cfe5b7d881b5a5ed5ff287e65/modules/app-notify/handlers/photoNotifications.js?at=develop#photoNotifications.js-8

https://bitbucket.org/joylife/joy/src/71be8ceae34e146cfe5b7d881b5a5ed5ff287e65/modules/people/firebaseDataSource.js?at=develop#firebaseDataSource.js-37