### PR TITLE
server-core - `id` column / UUIDs should be unique

### DIFF
--- a/src/middleware/error.logging.ts
+++ b/src/middleware/error.logging.ts
@@ -72,7 +72,6 @@ export function errorFormattingApollo(enrichedError: any): any {
     // why are we even here?
     return enrichedError;
   }
-console.log('---', JSON.stringify(enrichedError));
 
   const { message, name } = enrichedError;
   const code = get(enrichedError, 'extensions.code')

--- a/src/templates/entity.template.ts
+++ b/src/templates/entity.template.ts
@@ -1,11 +1,11 @@
-import { PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, VersionColumn, Column, Generated, Index } from 'typeorm';
+ import { PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, VersionColumn, Column, Generated, Index } from 'typeorm';
 
 export abstract class Template  {
 
   @PrimaryGeneratedColumn('increment')
   public key: number;
 
-  @Index()
+  @Index({ unique: true })
   @Column('uuid')
   @Generated('uuid')
   public id: string;


### PR DESCRIPTION
we aren't always relying upon TypeORM to auto-generate our UUIDs.  when we generate reproducible IDs during the Firebase import steps, we want to ensure they're unique from a database constraint perspective

`event_service` will execute the necessary migrations

## version MINOR

i am making this a MINOR version -- because there will be implications to taking on the unique key

the developer will need to revert and re-generate the Entity.id indexes -- there will be a pratical example of this in the `event_service` repo