### PR TITLE
server-core - GraphQL Date typedef fixes

### DIFF
--- a/test/apollo/core.types.date.ts
+++ b/test/apollo/core.types.date.ts
@@ -6,7 +6,7 @@ import { testSetupApollo } from '../helpers/apollo';
 
 
 // features
-//   EST vs. GMT
+//   EST vs. UTC
 //   has millisecond precision
 const DATE_ISO = '2016-11-09T02:30:00.5-05:00';
 const TZ_IANA = 'America/New_York';
@@ -58,9 +58,25 @@ describe('the GraphQL Date and Time TypeDefs', () => {
       });
     });
 
-    it('resolves a Unix timestamp without millisecond precision', async () => {
-      // ... which seems odd when the schema indicates `Float!`
+    it('resolves a millisecond timestamp', async () => {
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            date { milliseconds }
+          }
+        `
+      });
 
+      const { data } = res;
+      expect(data).toMatchObject({
+        date: {
+          milliseconds: 1478676600500,
+        },
+      });
+    });
+
+    it('resolves a Unix timestamp without millisecond precision', async () => {
       const { query } = client;
       const res = await query({
         query: gql`
@@ -78,7 +94,7 @@ describe('the GraphQL Date and Time TypeDefs', () => {
       });
     });
 
-    it('formats the associated timezone as GMT', async () => {
+    it('resolves the associated timezone as UTC', async () => {
       const { query } = client;
       const res = await query({
         query: gql`
@@ -93,13 +109,13 @@ describe('the GraphQL Date and Time TypeDefs', () => {
       const { data } = res;
       expect(data).toMatchObject({
         defaultFormat: {
-          timezone: 'Etc/GMT',
+          timezone: 'Etc/UTC',
         },
         long: {
-          timezone: 'Etc/GMT',
+          timezone: 'Etc/UTC',
         },
         short: {
-          timezone: 'GMT',
+          timezone: 'UTC',
         },
       });
     });
@@ -241,9 +257,25 @@ describe('the GraphQL Date and Time TypeDefs', () => {
       });
     });
 
-    it('resolves a Unix timestamp without millisecond precision', async () => {
-      // ... which seems odd when the schema indicates `Float!`
+    it('resolves a millisecond timestamp', async () => {
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            date { milliseconds }
+          }
+        `
+      });
 
+      const { data } = res;
+      expect(data).toMatchObject({
+        date: {
+          milliseconds: 1478676600500,
+        },
+      });
+    });
+
+    it('resolves a Unix timestamp without millisecond precision', async () => {
       const { query } = client;
       const res = await query({
         query: gql`
@@ -261,7 +293,7 @@ describe('the GraphQL Date and Time TypeDefs', () => {
       });
     });
 
-    it('formats the associated timezone', async () => {
+    it('resolves the associated timezone', async () => {
       const { query } = client;
       const res = await query({
         query: gql`
@@ -374,6 +406,206 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         },
         longTimeWithSeconds: {
           dateString: 'November 9, 2016 2:30:00 AM',
+        },
+      });
+    });
+  });
+
+
+  describe('with an ISO-8601 Date string + a missing time zone', () => {
+    beforeEach(async () => {
+      const setup = await testSetupApollo({
+        typeDefs: [
+          coreTypeDefs,
+          gql`
+            type Query {
+              date: Date!
+            }
+          `,
+        ],
+        resolvers: {
+          ...coreResolvers,
+
+          Query: {
+            // include a timezone,
+            //   which the caller probably doesn't know is blank
+            date: () => [ DATE_ISO, '' ],
+          },
+        },
+      });
+      client = setup.client;
+    });
+
+
+    it('resolves an ISO-8601 timestamp which does not reflect the specified timezone offset', async () => {
+      // ... which seems odd; why not provide the offset that the caller requested?
+
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            date { timestamp }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        date: {
+          timestamp: '2016-11-09T07:30:00.500Z',
+        },
+      });
+    });
+
+    it('resolves a millisecond timestamp', async () => {
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            date { milliseconds }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        date: {
+          milliseconds: 1478676600500,
+        },
+      });
+    });
+
+    it('resolves a Unix timestamp without millisecond precision', async () => {
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            date { unixTimestamp }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        date: {
+          unixTimestamp: 1478676600,
+        },
+      });
+    });
+
+    it('resolves the associated timezone as UTC', async () => {
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            defaultFormat: date { timezone }
+            long: date { timezone(format: Long) }
+            short: date { timezone(format: Short) }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        defaultFormat: {
+          timezone: 'Etc/UTC',
+        },
+        long: {
+          timezone: 'Etc/UTC',
+        },
+        short: {
+          timezone: 'UTC',
+        },
+      });
+    });
+
+    it('formats a Date string for the current locale', async () => {
+      // ... which happens to be 'en'
+      //   @see testSetupApollo
+
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            defaultFormat: date { dateString }
+            numerical: date { dateString(dateFormat: Numerical) }
+            short: date { dateString(dateFormat: Short) }
+            long: date { dateString(dateFormat: Long) }
+            full: date { dateString(dateFormat: Full) }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        defaultFormat: {
+          dateString: 'Wednesday, November 9, 2016 7:30 AM',
+        },
+        numerical: {
+          dateString: '11/9/2016',
+        },
+        short: {
+          dateString: 'Nov 9, 2016',
+        },
+        long: {
+          dateString: 'November 9, 2016',
+        },
+        full: {
+          dateString: 'Wednesday, November 9, 2016 7:30 AM',
+        },
+      });
+    });
+
+    it('formats a Time string for the current locale', async () => {
+      // ... which happens to be 'en'
+      //   @see testSetupApollo
+
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            defaultFormat: date { dateString }
+            time: date { dateString(timeFormat: Time) }
+            timeWithSeconds: date { dateString(timeFormat: TimeWithSeconds) }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        defaultFormat: {
+          dateString: 'Wednesday, November 9, 2016 7:30 AM',
+        },
+        time: {
+          dateString: '7:30 AM',
+        },
+        timeWithSeconds: {
+          dateString: '7:30:00 AM',
+        },
+      });
+    });
+
+    it('formats a Date-and-Time string for the current locale', async () => {
+      // ... which happens to be 'en'
+      //   @see testSetupApollo
+
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            shortTime: date { dateString(dateFormat: Short, timeFormat: Time) }
+            longTimeWithSeconds: date { dateString(dateFormat: Long, timeFormat: TimeWithSeconds) }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        shortTime: {
+          dateString: 'Nov 9, 2016 7:30 AM',
+        },
+        longTimeWithSeconds: {
+          dateString: 'November 9, 2016 7:30:00 AM',
         },
       });
     });


### PR DESCRIPTION
- Date { timezone } fallback to 'UTC' when timezone is blank
- Date { milliseconds } without 32-bit Int constraints
- Date { unixTimestamp } can be an Int