### PR TITLE
ENG-381 contiguous logging support for GraphQL Services

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,10 @@ module.exports = {
   coverageReporters: ['json', 'lcov', 'text'],
   coverageThreshold: {
     global: {
-      statements: 58.3,
-      branches: 54.3,
-      functions: 49.3,
-      lines: 59.0,
+      statements: 64.3,
+      branches: 64.9,
+      functions: 59.8,
+      lines: 65.0,
     },
   },
   globals: {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/lodash": "4.14.136",
     "@types/morgan": "1.7.35",
     "@types/node-fetch": "2.1.6",
+    "@withjoy/telemetry": "^0.4.3",
     "apollo": "^2.16.2",
     "apollo-link": "1.2.8",
     "apollo-link-http": "1.5.11",

--- a/src/authentication/token.check.spec.ts
+++ b/src/authentication/token.check.spec.ts
@@ -55,6 +55,10 @@ describe('token.check', () => {
         })
       )).toBeNull();
     });
+
+    it('derives from nothing', () => {
+      expect( deriveTokenHeaderValue(undefined) ).toBeNull();
+    });
   });
 
 

--- a/src/authentication/token.check.ts
+++ b/src/authentication/token.check.ts
@@ -1,13 +1,21 @@
 import { Request, Response, NextFunction } from 'express';
 import { verifyAll, TokenConfig } from './verify.token';
 
+
+export const NO_USER = 'no-user';
+export const NO_TOKEN = 'no-token';
+
 /**
  * Derives the token value -- usually a JWT -- from the 'Authorization' header.
  * What we call `req.token` is actually the full 'Authorization' header.
  *
  * eg. 'Authorization: Bearer TOKEN_VALUE' => TOKEN_VALUE
  */
-export const deriveTokenHeaderValue = (req: Request): string | null => {
+export const deriveTokenHeaderValue = (req: Request | undefined): string | null => {
+  if (! req) {
+    return null;
+  }
+
   const header = req.headers.authorization;
   if (! header) {
     return null;

--- a/src/authentication/verify.token.ts
+++ b/src/authentication/verify.token.ts
@@ -31,7 +31,7 @@ interface Auth0Token {
  * @param token a JWT token
  * @returns Auth0Token | Error
  */
-export const verifyAll = (tokenConfig: TokenConfig, token: string) => {
+export const verifyAll = (tokenConfig: TokenConfig, token: string): Auth0Token | Error => {
   return Object.keys(tokenConfig.auth0).map(key => {
     try {
       const secretObj = tokenConfig.auth0[key].secret;

--- a/src/graphql/interservice.communication.spec.ts
+++ b/src/graphql/interservice.communication.spec.ts
@@ -18,6 +18,9 @@ import {
 const SERVICE_URL = 'https://SERVICE_URL';
 const TOKEN = 'TOKEN';
 const VARIABLE = 'VARIABLE';
+const HEADERS = Object.freeze({
+  'x-joy-header': 'X-JOY-HEADER',
+});
 const PROPERTY = 'PRECIOUS';  // "my property!!!"
 const TEST_QUERY: DocumentNode = gql`
   query ($variable: String!) {
@@ -51,6 +54,7 @@ describe('graphql/interservice.communication', () => {
     const ARGS = {
       token: TOKEN,
       variables: { variable: VARIABLE },
+      headers: HEADERS,
     };
     let serviceCaller: ServiceCaller<TestOutput, TestQuery, TestVariables>;
 
@@ -79,8 +83,10 @@ describe('graphql/interservice.communication', () => {
     describe('#fetch', () => {
       it('returns the FetchResult from a successful execution', async () => {
         nock(SERVICE_URL, {
-          // it('provides the token for authorization')
           reqheaders: {
+            // it('provides the headers passed in args')
+            ...HEADERS,
+            // it('provides the token for authorization')
             authorization: TOKEN,
           },
         })
@@ -167,8 +173,10 @@ describe('graphql/interservice.communication', () => {
     describe('#execute', () => {
       it('returns the output from a successful execution', async () => {
         nock(SERVICE_URL, {
-          // it('provides the token for authorization')
           reqheaders: {
+            // it('provides the headers passed in args')
+            ...HEADERS,
+            // it('provides the token for authorization')
             authorization: TOKEN,
           },
         })
@@ -471,6 +479,7 @@ describe('graphql/interservice.communication', () => {
       const caller: IServiceCallerBuilderCaller<TestOutput, TestQuery, TestVariables> = builder({
         token: TOKEN,
         variables: { variable: VARIABLE },
+        headers: HEADERS,
       });
 
       expect(caller).toMatchObject({
@@ -493,6 +502,7 @@ describe('graphql/interservice.communication', () => {
       const fetchResult = await builder({
         token: TOKEN,
         variables: { variable: VARIABLE },
+        headers: HEADERS,
       }).fetch();
 
       expect(fetchResult).toEqual({
@@ -518,6 +528,7 @@ describe('graphql/interservice.communication', () => {
       const output = await builder({
         token: TOKEN,
         variables: { variable: VARIABLE },
+        headers: HEADERS,
       }).execute();
 
       expect(output).toEqual({

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,14 @@ import {
   IContext,
   ContextConstructorArgs,
   createContext,
+  logContextRequest,
 } from './server/apollo.context'
 import { IApolloServerArgs, createApolloServer } from './server/apollo.server'
 import { IServer, Server } from './server/server'
 import { initApp } from './server/server.init';
 import {
+  NO_USER,
+  NO_TOKEN,
   deriveTokenHeaderValue,
   tokenCheck,
 } from './authentication/token.check';
@@ -66,6 +69,7 @@ export {
   IContext,
   ContextConstructorArgs,
   createContext,
+  logContextRequest,
 
   IApolloServerArgs,
   createApolloServer,
@@ -80,6 +84,8 @@ export {
   ModelViewTemplate,
   ViewTemplate,
 
+  NO_USER,
+  NO_TOKEN,
   deriveTokenHeaderValue,
   tokenCheck,
 

--- a/src/server/apollo.context.spec.ts
+++ b/src/server/apollo.context.spec.ts
@@ -1,0 +1,461 @@
+import 'jest';
+import * as TypeMoq from 'typemoq';
+import nock from 'nock';
+import { createRequest } from 'node-mocks-http';
+import { DocumentNode } from 'graphql';
+import { gql } from 'apollo-server';
+import {
+  TELEMETRY_HEADER_HOSTNAME,
+  TELEMETRY_HEADER_PERSON_ID,
+  TELEMETRY_HEADER_REQUEST_ID,
+  Telemetry,
+} from '@withjoy/telemetry';
+
+import { NO_USER, NO_TOKEN } from '../authentication/token.check';
+import {
+  Context,
+  createContext,
+
+  logContextRequest,
+} from './apollo.context';
+
+const IDENTITY_URL = 'http://IDENTITY_URL';
+const TOKEN = 'TOKEN';
+const USER_ID = 'USER_ID';
+const LOCALE = 'LOCALE';
+const HEADERS = Object.freeze({
+  'x-joy-header': 'X-JOY-HEADER',
+});
+
+
+describe('server/apollo.context', () => {
+  let context: Context;
+
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.isDone();
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+
+  describe('Context', () => {
+    describe('given constructor args', () => {
+      it('populates an instance', () => {
+        const req = createRequest();
+
+        context = new Context({
+          req,
+          token: TOKEN,
+          userId: USER_ID,
+          identityUrl: IDENTITY_URL,
+          locale: LOCALE,
+        });
+
+        expect(context.req).toBe(req);
+        expect(context.token).toBe(TOKEN);
+        expect(context.userId).toBe(USER_ID);
+        expect(context.identityUrl).toBe(IDENTITY_URL);
+        expect(context.locale).toBe(LOCALE);
+
+        expect(context.telemetry).toBeDefined();
+        expect(context.currentUser).toBeUndefined();
+      });
+
+      it('inherits missing args from the request', () => {
+        context = new Context({
+          req: createRequest({
+            token: 'REQ_TOKEN',
+            userId: 'REQ_USER_ID',
+          }),
+          // no `token`
+          // no `userId`
+          identityUrl: IDENTITY_URL,
+          locale: LOCALE,
+        });
+
+        expect(context.token).toBe('REQ_TOKEN');
+        expect(context.userId).toBe('REQ_USER_ID');
+      });
+
+      it('derives a token from the request headers', () => {
+        context = new Context({
+          req: createRequest({
+            headers: {
+              authorization: 'Bearer AUTH_TOKEN',
+            },
+          }),
+          // no `token`
+          // no `userId`
+          identityUrl: IDENTITY_URL,
+          locale: LOCALE,
+        });
+
+        expect(context.token).toBe('AUTH_TOKEN');
+        expect(context.userId).toBe(NO_USER);
+      });
+
+      it('assumes a Telemetry context when the request does not provide headers', () => {
+        expect(context.telemetry.context()).toEqual({
+          hostname: expect.any(String),
+          requestId: expect.any(String),
+        });
+      });
+
+      it('derives a Telemetry context from the request headers', () => {
+        context = new Context({
+          req: createRequest({
+            headers: {
+              [ TELEMETRY_HEADER_HOSTNAME ]: 'HOSTNAME',
+              [ TELEMETRY_HEADER_PERSON_ID ]: 'PERSON_ID',
+              [ TELEMETRY_HEADER_REQUEST_ID ]: 'REQUEST_ID',
+            },
+          }),
+          token: TOKEN,
+          userId: USER_ID,
+          identityUrl: IDENTITY_URL,
+          locale: LOCALE,
+        });
+
+        const telemetryContext = context.telemetry.context();
+        expect(context.telemetry.context()).toEqual({
+          hostname: expect.any(String),
+          personId: 'PERSON_ID',
+          requestId: 'REQUEST_ID',
+        });
+        expect(telemetryContext.hostname).not.toBe('HOSTNAME'); // Server-generated vs. derived
+      });
+    });
+
+    describe('without any constructor args', () => {
+      beforeEach(() => {
+        context = new Context();
+      });
+
+      it('populates an instance', () => {
+        expect(context.req).toBeUndefined();
+        expect(context.token).toBe(NO_TOKEN);
+        expect(context.userId).toBe(NO_USER);
+        expect(context.identityUrl).toBeUndefined();
+        expect(context.locale).toBe('en_US');
+
+        expect(context.telemetry).toBeDefined();
+        expect(context.currentUser).toBeUndefined();
+      });
+
+      it('assumes a Telemetry context', () => {
+        expect(context.telemetry.context()).toEqual({
+          hostname: expect.any(String),
+          requestId: expect.any(String),
+        });
+      });
+    });
+  });
+
+
+  describe('createContext', () => {
+    const existingContext = new Context();
+
+    it('returns the Context passed to it', () => {
+      expect( createContext(existingContext) ).toBe(existingContext);
+    });
+
+    it('constructs a fresh default Context', () => {
+      context = createContext(existingContext);
+
+      expect(context).toBeInstanceOf(Context);
+
+      expect(context.req).toBeUndefined();
+      expect(context.token).toBe(NO_TOKEN);
+      expect(context.userId).toBe(NO_USER);
+      expect(context.identityUrl).toBeUndefined();
+      expect(context.locale).toBe('en_US');
+
+      expect(context.telemetry).toBeDefined();
+      expect(context.currentUser).toBeUndefined();
+    });
+  });
+
+
+  describe('#me', () => {
+    beforeEach(() => {
+      context = new Context({
+        req: createRequest({
+          headers: {
+            [ TELEMETRY_HEADER_REQUEST_ID ]: 'REQUEST_ID',
+          },
+        }),
+        token: TOKEN,
+        identityUrl: IDENTITY_URL,
+      });
+
+      expect(context.userId).toBe(NO_USER);
+      expect(context.currentUser).toBeUndefined();
+    });
+
+    it('identifies the User by token', async () => {
+      nock(IDENTITY_URL, {
+        reqheaders: {
+          // it('authorizes with the Context token')
+          authorization: TOKEN,
+
+          // it('passes along Telemetry headers')
+          [ TELEMETRY_HEADER_REQUEST_ID ]: 'REQUEST_ID',
+        },
+      })
+      .post('/', (body: any) => {
+        expect( gql`${ body.query }` ).toMatchObject({
+          definitions: [
+            {
+              kind: 'FragmentDefinition',
+              name: {
+                value: 'UserFragment',
+              },
+            },
+            {
+              operation: 'query',
+              name: {
+                value: "GetMe"
+              },
+              selectionSet: {
+                selections: [
+                  {
+                    name: {
+                      // the { query }
+                      value: 'me',
+                    },
+                    arguments: [],
+                    selectionSet: {
+                      selections: [
+                        {
+                          name: {
+                            value: 'UserFragment',
+                          },
+                        }
+                      ]
+                    }
+                  },
+                ],
+              },
+              variableDefinitions: [],
+            },
+          ],
+        });
+
+        return true; // yep, that's what we're looking for
+      })
+      .reply(200, {
+        data: {
+          me: {
+            id: 'ME_ID',
+          },
+        },
+      });
+
+      await context.me();
+
+      expect(context.userId).toBe('ME_ID');
+      expect(context.currentUser).toEqual({
+        id: 'ME_ID',
+      });
+    });
+
+    it('does nothing when there is no data', async () => {
+      nock(IDENTITY_URL)
+      .post('/', (body: any) => body.query.match(/GetMe/))
+      .reply(200, {});
+
+      await context.me();
+
+      expect(context.userId).toBe(NO_USER);
+      expect(context.currentUser).toBeUndefined();
+    });
+
+    it('does nothing upon Error', async () => {
+      nock(IDENTITY_URL)
+      .post('/', (body: any) => body.query.match(/GetMe/))
+      .reply(401);
+
+      await context.me();
+
+      expect(context.userId).toBe(NO_USER);
+      expect(context.currentUser).toBeUndefined();
+    });
+
+    it('allows for overrides', async () => {
+      nock(IDENTITY_URL, {
+        reqheaders: {
+          authorization: 'CUSTOM_TOKEN',
+          [ TELEMETRY_HEADER_REQUEST_ID ]: 'REQUEST_ID',
+          'x-joy-custom': 'CUSTOM_HEADER',
+        },
+      })
+      .post('/', (body: any) => body.query.match(/GetMe/))
+      .reply(200, {
+        data: {
+          me: {
+            id: 'ME_ID',
+          },
+        },
+      });
+
+      await context.me({
+        token: 'CUSTOM_TOKEN',
+        headers: { 'x-joy-custom': 'CUSTOM_HEADER' },
+      });
+
+      expect(context.userId).toBe('ME_ID');
+      expect(context.currentUser).toEqual({
+        id: 'ME_ID',
+      });
+    });
+  });
+
+
+  describe('logContextRequest', () => {
+    let telemetryMock: TypeMoq.IMock<Telemetry>;
+
+    beforeEach(() => {
+      telemetryMock = TypeMoq.Mock.ofType(Telemetry);
+    });
+    afterEach(() => {
+      telemetryMock.verifyAll();
+    });
+
+    it('logs a GraphQL request', () => {
+      const query = `
+        query DEFINITION_1 {
+          selection_1A(param: "value") {
+            property
+          }
+          selection_1B
+        }
+        mutation DEFINITION_2 {
+          selection_2A(param: "value") {
+            property
+          }
+        }
+      `;
+
+      context = new Context({
+        req: createRequest({
+          method: 'POST',
+          url: 'http://HOSTNAME/PATH',
+          body: { query },
+        }),
+        token: TOKEN,
+        userId: USER_ID,
+      });
+      Reflect.set(context, 'telemetry', telemetryMock.object);
+
+      telemetryMock.setup((mocked) => mocked.info('logContextRequest', {
+        source: 'express',
+        action: 'request',
+        req: {
+          method: 'POST',
+          path: '/PATH',
+          token: TOKEN,
+          userId: USER_ID,
+        },
+        graphql: {
+          operations: [
+            {
+              definitionName: 'DEFINITION_1',
+              operation: 'query',
+              selectionName: 'selection_1A',
+            },
+            {
+              definitionName: 'DEFINITION_1',
+              operation: 'query',
+              selectionName: 'selection_1B',
+            },
+            {
+              definitionName: 'DEFINITION_2',
+              operation: 'mutation',
+              selectionName: 'selection_2A',
+            },
+          ],
+        },
+      }))
+      .verifiable(TypeMoq.Times.exactly(1));
+
+      logContextRequest(context);
+    });
+
+    it('logs a REST-y GET request', () => {
+      context = new Context({
+        req: createRequest({
+          method: 'GET',
+          url: 'http://HOSTNAME/PATH',
+          query: { param: true },
+        }),
+        token: TOKEN,
+        userId: USER_ID,
+      });
+      Reflect.set(context, 'telemetry', telemetryMock.object);
+
+      telemetryMock.setup((mocked) => mocked.info('logContextRequest', {
+        source: 'express',
+        action: 'request',
+        req: {
+          method: 'GET',
+          path: '/PATH',
+          token: TOKEN,
+          userId: USER_ID,
+        },
+        graphql: {
+          operations: [],
+        },
+      }))
+      .verifiable(TypeMoq.Times.exactly(1));
+
+      logContextRequest(context);
+    });
+
+    it('logs a REST-y POST request', () => {
+      context = new Context({
+        req: createRequest({
+          method: 'POST',
+          url: 'http://HOSTNAME/PATH',
+          body: { param: true },
+        }),
+        token: TOKEN,
+        userId: USER_ID,
+      });
+      Reflect.set(context, 'telemetry', telemetryMock.object);
+
+      telemetryMock.setup((mocked) => mocked.info('logContextRequest', {
+        source: 'express',
+        action: 'request',
+        req: {
+          method: 'POST',
+          path: '/PATH',
+          token: TOKEN,
+          userId: USER_ID,
+        },
+        graphql: {
+          operations: [],
+        },
+      }))
+      .verifiable(TypeMoq.Times.exactly(1));
+
+      logContextRequest(context);
+    });
+
+    it('does not log without a request', () => {
+      context = new Context({
+        token: TOKEN,
+        userId: USER_ID,
+      });
+      Reflect.set(context, 'telemetry', telemetryMock.object);
+
+      telemetryMock.setup((mocked) => mocked.info('logContextRequest', TypeMoq.It.isObjectWith({})))
+      .verifiable(TypeMoq.Times.never());
+
+      logContextRequest(context);
+    });
+  });
+});

--- a/src/server/apollo.server.ts
+++ b/src/server/apollo.server.ts
@@ -1,14 +1,23 @@
 import { ApolloServer } from 'apollo-server-express';
 import { Config } from 'apollo-server';
-import { errorFormattingApollo } from '../middleware/error.logging';
+import { errorLoggingApolloPlugin } from '../middleware/error.logging';
 
 export interface IApolloServerArgs extends Config {
   contextFunc?: (ctx: any) => any;
 }
 
 export const createApolloServer = (args: IApolloServerArgs) => {
+  const plugins = args.plugins || [];
+
   const server = new ApolloServer({
     ...args,
+
+    plugins: [
+      ...plugins,
+
+      errorLoggingApolloPlugin,
+    ],
+
     context: (ctx: any) => {
       if (args.contextFunc) {
         return args.contextFunc(ctx);
@@ -16,7 +25,15 @@ export const createApolloServer = (args: IApolloServerArgs) => {
         return ctx;
       }
     },
-    formatError: errorFormattingApollo,
+
+    // NOTE: not useful
+    //   `formatError(error: GraphQLError): GraphQLFormattedError`
+    //   provides no access to Context#telemetry
+    // TODO: potentially useful
+    //   `rewriteError(err: GraphQLError): GraphQLError | null { ... }`
+    //   if we want to hide some Errors from `stitch_service`
+    //   @see https://www.apollographql.com/docs/apollo-server/data/errors/#for-apollo-graph-manager-reporting
   });
+
   return server;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3,9 +3,12 @@ import express, { Request, Response, RequestHandler, ErrorRequestHandler, Router
 import cors from 'cors';
 import morgan from 'morgan';
 import bodyParser from 'body-parser';
+import { telemetry, deriveTelemetryContextFromError } from '@withjoy/telemetry';
+
 import { bodyParserGraphql } from '../middleware/body.parser';
 import { errorLoggingExpress } from '../middleware/error.logging';
 import { ApolloServer } from 'apollo-server-express';
+
 
 export interface IServer {
   init: (port: number) => Promise<{ port: number }>;
@@ -67,7 +70,10 @@ export class Server implements IServer {
       this.httpServer = httpServer;
 
       const onError = (err: Error) => {
-        console.error(err);
+        telemetry.error('Server#bootHttpServer', {
+          ...deriveTelemetryContextFromError(err),
+          port,
+        });
         httpServer.close();
         reject(err)
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,6 +610,24 @@
     "@types/events" "*"
     "@types/node" "*"
 
+"@withjoy/error@*":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@withjoy/error/-/error-0.0.2.tgz#f67d608d9be50ef1d313a91397950212f4fe0803"
+  integrity sha512-BnJEt8/2tafn9KtHzS1O8ZMtxz3jVYXKkaLvbKltD0LjUA4z6Iq74XqMY4X3sy/TLx6UmUGBQfPXv1xrTDjiPQ==
+
+"@withjoy/telemetry@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@withjoy/telemetry/-/telemetry-0.4.3.tgz#6a3bdd1126136ada3ee2f658d38544cd1e500e40"
+  integrity sha512-qvXa6RnN1QsBxo1EpLofZ+Fp9EsQTo1tUjgzlH+sbc7tWmmFoLcGlwDo5QdUt0Fnpu3bK6fhYM5YbtIBCFvsxA==
+  dependencies:
+    "@types/node" "*"
+    "@withjoy/error" "*"
+    bluebird "^3.5.0"
+    chalk "^1.1.3"
+    extend "^3.0.1"
+    le_node "^1.7.0"
+    universal-analytics "^0.4.13"
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -1236,6 +1254,13 @@ babel-preset-jest@^24.1.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.1.0"
 
+babel-runtime@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.6.1.tgz#788b94b6f634e25b91bd6c5df72d467457afb000"
+  integrity sha1-eIuUtvY04luRvWxd9y1GdFevsAA=
+  dependencies:
+    core-js "^2.1.0"
+
 babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
@@ -1246,6 +1271,13 @@ babel-runtime@^6.26.0:
 backo2@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+
+backoff@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/backoff/-/backoff-2.5.0.tgz#f616eda9d3e4b66b8ca7fca79f695722c5f8e26f"
+  integrity sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=
+  dependencies:
+    precond "0.2"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1278,6 +1310,11 @@ bcrypt-pbkdf@^1.0.0:
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
   dependencies:
     tweetnacl "^0.14.3"
+
+bluebird@^3.5.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
+  integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
 
 body-parser@1.18.3, body-parser@^1.18.3:
   version "1.18.3"
@@ -1638,6 +1675,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+codependency@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/codependency/-/codependency-0.1.4.tgz#d1763ab7264bd70c91d9626e98862d3792bf8d4a"
+  integrity sha1-0XY6tyZL1wyR2WJumIYtN5K/jUo=
+  dependencies:
+    semver "5.0.1"
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -1717,6 +1761,11 @@ cookie@0.3.1:
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+
+core-js@^2.1.0:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
+  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.4"
@@ -1803,9 +1852,10 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.0.0, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
@@ -2182,9 +2232,10 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.1, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 extglob@^2.0.4:
   version "2.0.4"
@@ -3484,9 +3535,10 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@5.0.1, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@2.x, json5@^2.1.0:
   version "2.1.0"
@@ -3579,6 +3631,18 @@ lcid@^2.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
   dependencies:
     invert-kv "^2.0.0"
+
+le_node@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/le_node/-/le_node-1.8.0.tgz#07b1ae7d0c8f36a8e9892650c25f711b8a403f83"
+  integrity sha512-NXzjxBskZ4QawTNwlGdRG05jYU0LhV2nxxmP3x7sRMHyROV0jPdyyikO9at+uYrWX3VFt0Y/am11oKITedx0iw==
+  dependencies:
+    babel-runtime "6.6.1"
+    codependency "0.1.4"
+    json-stringify-safe "5.0.1"
+    lodash "4.17.11"
+    reconnect-core "1.3.0"
+    semver "5.1.0"
 
 left-pad@^1.3.0:
   version "1.3.0"
@@ -3743,14 +3807,15 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash@4.17.11, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
 lodash@4.17.13:
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
   integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
-
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 lodash@^4.17.13, lodash@^4.17.5:
   version "4.17.15"
@@ -4554,6 +4619,11 @@ postinstall-build@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-5.0.3.tgz#238692f712a481d8f5bc8960e94786036241efc7"
 
+precond@0.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/precond/-/precond-0.2.3.tgz#aa9591bcaa24923f1e0f4849d240f47efc1075ac"
+  integrity sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -4726,6 +4796,13 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+reconnect-core@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/reconnect-core/-/reconnect-core-1.3.0.tgz#fbae52919a7877d844e3246d01a2f26701c833c8"
+  integrity sha1-+65SkZp4d9hE4yRtAaLyZwHIM8g=
+  dependencies:
+    backoff "~2.5.0"
+
 redeyed@~2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-2.1.1.tgz#8984b5815d99cb220469c99eeeffe38913e6cc0b"
@@ -4784,9 +4861,10 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.87.0:
+request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -4915,6 +4993,16 @@ sax@>=0.6.0, sax@^1.2.4:
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+
+semver@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.1.tgz#9fb3f4004f900d83c47968fe42f7583e05832cc9"
+  integrity sha1-n7P0AE+QDYPEeWj+QvdYPgWDLMk=
+
+semver@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.1.0.tgz#85f2cf8550465c4df000cf7d86f6b054106ab9e5"
+  integrity sha1-hfLPhVBGXE3wAM99hvawVBBqueU=
 
 send@0.16.2:
   version "0.16.2"
@@ -5536,6 +5624,15 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
+universal-analytics@^0.4.13:
+  version "0.4.20"
+  resolved "https://registry.yarnpkg.com/universal-analytics/-/universal-analytics-0.4.20.tgz#d6b64e5312bf74f7c368e3024a922135dbf24b03"
+  integrity sha512-gE91dtMvNkjO+kWsPstHRtSwHXz0l2axqptGYp5ceg4MsuurloM0PU3pdOfpb5zBXUvyjT4PwhWK2m39uczZuw==
+  dependencies:
+    debug "^3.0.0"
+    request "^2.88.0"
+    uuid "^3.0.0"
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -5599,6 +5696,11 @@ util.promisify@1.0.0, util.promisify@^1.0.0:
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+
+uuid@^3.0.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
 uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
- formal @withjoy/telemetry integration
- `logContextRequest` for contiguous logging support
- Context-aware Plugin strategy for Apollo Error logging
- Context self-derives its #telemetry context
- custom header support for ServiceCaller & peers
- Context#me accepts ServiceCaller overrides
- added Context#req
- a Context can act as its own constructor args
- constants for 'no-user', 'no-token' also used by Apps
- upped coverage thresholds