### PR TITLE
ENG-746 camelCase (vs. PascalCase) for "core" typedef Enum values

### DIFF
--- a/src/graphql/core.types.ts
+++ b/src/graphql/core.types.ts
@@ -41,20 +41,20 @@ export const coreTypeDefs = gql`
   }
 
   enum TimezoneFormat {
-    Short
-    Long
+    short
+    long
   }
 
   enum DateFormat {
-    Numerical
-    Short
-    Long
-    Full
+    numerical
+    short
+    long
+    full
   }
 
   enum TimeFormat {
-    Time
-    TimeWithSeconds
+    time
+    timeWithSeconds
   }
 
   "An ISO-8601 timestamp"
@@ -81,30 +81,30 @@ const convertDate = (date: string | [string, string]) => {
 }
 
 enum TimezoneFormat {
-  Long = 'Long',
-  Short = 'Short'
+  long = 'long',
+  short = 'short',
 }
 
 enum DateFormat {
-  Numerical = 'Numerical',
-  Short = 'Short',
-  Long = 'Long',
-  Full = 'Full',
+  numerical = 'numerical',
+  short = 'short',
+  long = 'long',
+  full = 'full',
 }
 
 enum TimeFormat {
-  Time = 'Time',
-  TimeWithSeconds = 'TimeWithSeconds'
+  time = 'time',
+  timeWithSeconds = 'timeWithSeconds',
 }
 
 const convertEnumToMomentFormat = (format?: DateFormat | TimeFormat) => {
   switch (format) {
-    case TimeFormat.Time: return 'LT';
-    case TimeFormat.TimeWithSeconds: return 'LTS';
-    case DateFormat.Numerical: return 'l';
-    case DateFormat.Short: return 'll';
-    case DateFormat.Long: return 'LL';
-    case DateFormat.Full: return 'LLLL';
+    case TimeFormat.time: return 'LT';
+    case TimeFormat.timeWithSeconds: return 'LTS';
+    case DateFormat.numerical: return 'l';
+    case DateFormat.short: return 'll';
+    case DateFormat.long: return 'LL';
+    case DateFormat.full: return 'LLLL';
     default: return undefined;
   }
 }
@@ -118,7 +118,7 @@ export const coreResolvers: IResolvers = {
     timezone:(date: string | [string, string], args: { format: TimezoneFormat }) => {
       const { format } = args;
       const convertedDate = convertDate(date);
-      if (format === TimezoneFormat.Short) {
+      if (format === TimezoneFormat.short) {
         return convertedDate.zoneAbbr() || UTC_SHORT;
       } else {
         return convertedDate.tz() || UTC_LONG;
@@ -143,7 +143,7 @@ export const coreResolvers: IResolvers = {
       } else if (timeFormat) {
         return convertedDate.locale(context.locale).format(timeFormat);
       } else {
-        const full = convertEnumToMomentFormat(DateFormat.Full);
+        const full = convertEnumToMomentFormat(DateFormat.full);
         return convertedDate.locale(context.locale).format(full);
       }
     },

--- a/test/apollo/core.types.date.ts
+++ b/test/apollo/core.types.date.ts
@@ -100,8 +100,8 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         query: gql`
           query {
             defaultFormat: date { timezone }
-            long: date { timezone(format: Long) }
-            short: date { timezone(format: Short) }
+            long: date { timezone(format: long) }
+            short: date { timezone(format: short) }
           }
         `
       });
@@ -129,10 +129,10 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         query: gql`
           query {
             defaultFormat: date { dateString }
-            numerical: date { dateString(dateFormat: Numerical) }
-            short: date { dateString(dateFormat: Short) }
-            long: date { dateString(dateFormat: Long) }
-            full: date { dateString(dateFormat: Full) }
+            numerical: date { dateString(dateFormat: numerical) }
+            short: date { dateString(dateFormat: short) }
+            long: date { dateString(dateFormat: long) }
+            full: date { dateString(dateFormat: full) }
           }
         `
       });
@@ -166,8 +166,8 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         query: gql`
           query {
             defaultFormat: date { dateString }
-            time: date { dateString(timeFormat: Time) }
-            timeWithSeconds: date { dateString(timeFormat: TimeWithSeconds) }
+            time: date { dateString(timeFormat: time) }
+            timeWithSeconds: date { dateString(timeFormat: timeWithSeconds) }
           }
         `
       });
@@ -194,8 +194,8 @@ describe('the GraphQL Date and Time TypeDefs', () => {
       const res = await query({
         query: gql`
           query {
-            shortTime: date { dateString(dateFormat: Short, timeFormat: Time) }
-            longTimeWithSeconds: date { dateString(dateFormat: Long, timeFormat: TimeWithSeconds) }
+            shortTime: date { dateString(dateFormat: short, timeFormat: time) }
+            longTimeWithSeconds: date { dateString(dateFormat: long, timeFormat: timeWithSeconds) }
           }
         `
       });
@@ -299,8 +299,8 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         query: gql`
           query {
             defaultFormat: date { timezone }
-            long: date { timezone(format: Long) }
-            short: date { timezone(format: Short) }
+            long: date { timezone(format: long) }
+            short: date { timezone(format: short) }
           }
         `
       });
@@ -328,10 +328,10 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         query: gql`
           query {
             defaultFormat: date { dateString }
-            numerical: date { dateString(dateFormat: Numerical) }
-            short: date { dateString(dateFormat: Short) }
-            long: date { dateString(dateFormat: Long) }
-            full: date { dateString(dateFormat: Full) }
+            numerical: date { dateString(dateFormat: numerical) }
+            short: date { dateString(dateFormat: short) }
+            long: date { dateString(dateFormat: long) }
+            full: date { dateString(dateFormat: full) }
           }
         `
       });
@@ -365,8 +365,8 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         query: gql`
           query {
             defaultFormat: date { dateString }
-            time: date { dateString(timeFormat: Time) }
-            timeWithSeconds: date { dateString(timeFormat: TimeWithSeconds) }
+            time: date { dateString(timeFormat: time) }
+            timeWithSeconds: date { dateString(timeFormat: timeWithSeconds) }
           }
         `
       });
@@ -393,8 +393,8 @@ describe('the GraphQL Date and Time TypeDefs', () => {
       const res = await query({
         query: gql`
           query {
-            shortTime: date { dateString(dateFormat: Short, timeFormat: Time) }
-            longTimeWithSeconds: date { dateString(dateFormat: Long, timeFormat: TimeWithSeconds) }
+            shortTime: date { dateString(dateFormat: short, timeFormat: time) }
+            longTimeWithSeconds: date { dateString(dateFormat: long, timeFormat: timeWithSeconds) }
           }
         `
       });
@@ -499,8 +499,8 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         query: gql`
           query {
             defaultFormat: date { timezone }
-            long: date { timezone(format: Long) }
-            short: date { timezone(format: Short) }
+            long: date { timezone(format: long) }
+            short: date { timezone(format: short) }
           }
         `
       });
@@ -528,10 +528,10 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         query: gql`
           query {
             defaultFormat: date { dateString }
-            numerical: date { dateString(dateFormat: Numerical) }
-            short: date { dateString(dateFormat: Short) }
-            long: date { dateString(dateFormat: Long) }
-            full: date { dateString(dateFormat: Full) }
+            numerical: date { dateString(dateFormat: numerical) }
+            short: date { dateString(dateFormat: short) }
+            long: date { dateString(dateFormat: long) }
+            full: date { dateString(dateFormat: full) }
           }
         `
       });
@@ -565,8 +565,8 @@ describe('the GraphQL Date and Time TypeDefs', () => {
         query: gql`
           query {
             defaultFormat: date { dateString }
-            time: date { dateString(timeFormat: Time) }
-            timeWithSeconds: date { dateString(timeFormat: TimeWithSeconds) }
+            time: date { dateString(timeFormat: time) }
+            timeWithSeconds: date { dateString(timeFormat: timeWithSeconds) }
           }
         `
       });
@@ -593,8 +593,8 @@ describe('the GraphQL Date and Time TypeDefs', () => {
       const res = await query({
         query: gql`
           query {
-            shortTime: date { dateString(dateFormat: Short, timeFormat: Time) }
-            longTimeWithSeconds: date { dateString(dateFormat: Long, timeFormat: TimeWithSeconds) }
+            shortTime: date { dateString(dateFormat: short, timeFormat: time) }
+            longTimeWithSeconds: date { dateString(dateFormat: long, timeFormat: timeWithSeconds) }
           }
         `
       });


### PR DESCRIPTION
- applied to DateFormat, TimeFormat, TimezoneFormat
- verified schema:check from `stitch_service` + ALL local services