### PR TITLE
ENG-559 middleware support for avoiding HTTP 413 errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { IApolloServerArgs, createApolloServer } from './server/apollo.server'
 import { IServer, Server } from './server/server'
 import { initApp } from './server/server.init';
+import { getDefaultMiddleware } from './middleware/defaults';
 import {
   NO_USER,
   NO_TOKEN,
@@ -86,6 +87,7 @@ export {
   IServer,
   Server,
   initApp,
+  getDefaultMiddleware,
 
   ControllerTemplate,
   ModelTemplate,

--- a/src/middleware/defauits.spec.ts
+++ b/src/middleware/defauits.spec.ts
@@ -1,0 +1,48 @@
+import 'jest';
+
+import {
+  getDefaultMiddleware,
+} from './defaults';
+
+
+describe('middleware/defaults', () => {
+  describe('getDefaultMiddleware', () => {
+    it('returns "prelude" middleware', () => {
+      const { preludesMap, preludes } = getDefaultMiddleware();
+
+      const NAMES = [
+        'corsMiddleware',
+        'logger',
+      ];
+      expect(Array.from(preludesMap.keys())).toEqual(NAMES);
+
+      // it('preserves the order of the mapping')
+      expect( preludes.map((handler) => handler.name) ).toEqual(NAMES);
+    });
+
+    it('returns `body-parser` middleware', () => {
+      const { bodyParsersMap, bodyParsers } = getDefaultMiddleware();
+
+      const NAMES = [
+        'jsonParser',
+        'urlencodedParser',
+      ];
+      expect(Array.from(bodyParsersMap.keys())).toEqual(NAMES);
+
+      // it('preserves the order of the mapping')
+      expect( bodyParsers.map((handler) => handler.name) ).toEqual(NAMES);
+    });
+
+    it('returns Apollo-specific middleware', () => {
+      const { apolloMap, apollo } = getDefaultMiddleware();
+
+      const NAMES = [
+        'bodyParserGraphql',
+      ];
+      expect(Array.from(apolloMap.keys())).toEqual(NAMES);
+
+      // it('preserves the order of the mapping')
+      expect( apollo.map((handler) => handler.name) ).toEqual(NAMES);
+    });
+  });
+});

--- a/src/middleware/defaults.ts
+++ b/src/middleware/defaults.ts
@@ -1,0 +1,48 @@
+import { RequestHandler } from 'express';
+import cors from 'cors';
+import morgan from 'morgan';
+import bodyParser from 'body-parser';
+
+import { bodyParserGraphql } from './body.parser';
+
+interface DefaultMiddlewareResult {
+  preludesMap: Map<string, RequestHandler>;
+  preludes: RequestHandler[];
+  bodyParsersMap: Map<string, RequestHandler>;
+  bodyParsers: RequestHandler[];
+  apolloMap: Map<string, RequestHandler>;
+  apollo: RequestHandler[];
+};
+
+
+function _tupleByMiddlewareName(handler: RequestHandler): [ string, RequestHandler ] {
+  // keyed by the names Express would give them
+  return [ handler.name, handler ];
+}
+
+
+export function getDefaultMiddleware(): DefaultMiddlewareResult {
+  const preludesMap = new Map<string, RequestHandler>([
+    cors(),
+    morgan('dev'),
+  ].map(_tupleByMiddlewareName));
+
+  const bodyParsersMap = new Map<string, RequestHandler>([
+    // calling out the default(s) -- @see https://github.com/expressjs/body-parser#bodyparserjsonoptions
+    bodyParser.json({ limit: '100Kb' }),
+    bodyParser.urlencoded({ extended: false }),
+  ].map(_tupleByMiddlewareName));
+
+  const apolloMap = new Map<string, RequestHandler>([
+    bodyParserGraphql,
+  ].map(_tupleByMiddlewareName));
+
+  return {
+    preludesMap,
+    get preludes() { return Array.from(preludesMap.values()); },
+    bodyParsersMap,
+    get bodyParsers() { return Array.from(bodyParsersMap.values()); },
+    apolloMap,
+    get apollo() { return Array.from(apolloMap.values()); },
+  };
+}

--- a/src/middleware/error.logging.spec.ts
+++ b/src/middleware/error.logging.spec.ts
@@ -3,7 +3,6 @@ import * as TypeMoq from 'typemoq';
 import { noop, omit } from 'lodash';
 import { createRequest, createResponse, Headers } from 'node-mocks-http';
 import { Request, Response, NextFunction } from 'express';
-import { GraphQLError } from 'graphql';
 import { telemetry, Telemetry } from '@withjoy/telemetry';
 
 import { Context } from '../server/apollo.context';
@@ -15,7 +14,7 @@ import {
 } from './error.logging';
 
 
-describe('error.logging', () => {
+describe('middleware/error.logging', () => {
   let telemetryMock: TypeMoq.IMock<Telemetry>;
   let telemetryError: Function;
 

--- a/src/middleware/error.logging.ts
+++ b/src/middleware/error.logging.ts
@@ -1,4 +1,3 @@
-import urlLib from 'url';
 import {
   isError,
   pick,
@@ -37,7 +36,7 @@ export const errorLoggingExpress: ErrorRequestHandler = function errorLoggingExp
   // what was requested
   const requested = pick(req, 'path', 'params', 'query', 'body');
 
-  const { statusCode, code } = (err as any); // "Property 'FOO' does not exist on type 'Error'."
+  const { statusCode } = (err as any); // "Property 'FOO' does not exist on type 'Error'."
   let responded: Record<string, any>;
   let logged: Record<string, any>;
 


### PR DESCRIPTION
- getDefaultMiddleware => { preludes, bodyParsers, apollo }
- provide as Arrays and as a Map-by-Express-name for easy lookup