### PR TITLE
ENG-1813 exported logs are unusable

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepublishOnly": "yarn test",
     "build": "tsc",
     "test": "NODE_ENV=test jest --detectOpenHandles --no-cache --forceExit --config jest.config.js",
+    "test:only": "NODE_ENV=test TERM=dumb  node  node_modules/.bin/jest  -i --no-coverage --no-verbose  --detectOpenHandles --forceExit --config jest.config.js",
     "gentype:local": "apollo client:codegen --endpoint=http://localhost:9091/graphql --target=typescript --includes=src/**/*.ts --outputFlat=src/graphql/generated.typings.ts",
     "gentype:dev": "apollo client:codegen --endpoint=https://bliss-gateway-staging.withjoy.com/graphql --target=typescript --includes=src/**/*.ts --outputFlat=src/graphql/generated.typings.ts",
     "prepare": "yarn build",

--- a/src/graphql/interservice.communication.ts
+++ b/src/graphql/interservice.communication.ts
@@ -43,8 +43,8 @@ export const callService = <Query, Variables = undefined>(
           telemetry.error('callService', {
             ...deriveTelemetryContextFromError(err),
             serviceUrl,
-            query,
-            variables,
+            query: JSON.stringify(query),
+            variables: JSON.stringify(variables),
           });
           resolve();
         }

--- a/src/middleware/error.logging.spec.ts
+++ b/src/middleware/error.logging.spec.ts
@@ -69,9 +69,33 @@ describe('middleware/error.logging', () => {
         },
         request: {
           path: '/path',
-          params: { params: true },
-          query: { query: true },
-          body: { body: true },
+          params: JSON.stringify({ params: true }),
+          query: JSON.stringify({ query: true }),
+          body: JSON.stringify({ body: true }),
+        },
+      }))
+      .verifiable(TypeMoq.Times.exactly(1));
+
+      errorLoggingExpress(err, req, res, nextMock.object);
+    });
+
+    it('logs an Error for a sparse request', () => {
+      req = createRequest({
+        path: '/path',
+      });
+
+      telemetryMock.setup((mocked) => mocked.error('errorLoggingExpress', {
+        source: 'express',
+        action: 'error',
+        error: {
+          message: 'BOOM',
+          name: 'Error',
+          stack: 'STACK',
+          statusCode: undefined,
+          code: undefined,
+        },
+        request: {
+          path: '/path',
         },
       }))
       .verifiable(TypeMoq.Times.exactly(1));
@@ -140,9 +164,9 @@ describe('middleware/error.logging', () => {
         },
         request: {
           path: '/path',
-          params: { params: true },
-          query: { query: true },
-          body: { body: true },
+          params: JSON.stringify({ params: true }),
+          query: JSON.stringify({ query: true }),
+          body: JSON.stringify({ body: true }),
         },
       }))
       .verifiable(TypeMoq.Times.exactly(1));
@@ -187,9 +211,9 @@ describe('middleware/error.logging', () => {
         },
         request: {
           path: '/path',
-          params: { params: true },
-          query: { query: true },
-          body: { body: true },
+          params: JSON.stringify({ params: true }),
+          query: JSON.stringify({ query: true }),
+          body: JSON.stringify({ body: true }),
         },
       }))
       .verifiable(TypeMoq.Times.exactly(1));

--- a/src/server/apollo.context.spec.ts
+++ b/src/server/apollo.context.spec.ts
@@ -695,7 +695,7 @@ describe('server/apollo.context', () => {
           path: '/PATH',
         },
         graphql: {
-          operations: [
+          operations: JSON.stringify([
             {
               definitionName: 'DEFINITION_1',
               operation: 'query',
@@ -711,7 +711,7 @@ describe('server/apollo.context', () => {
               operation: 'mutation',
               selectionName: 'selection_2A',
             },
-          ],
+          ]),
         },
       }))
       .verifiable(TypeMoq.Times.exactly(1));
@@ -738,9 +738,6 @@ describe('server/apollo.context', () => {
           method: 'GET',
           path: '/PATH',
         },
-        graphql: {
-          operations: [],
-        },
       }))
       .verifiable(TypeMoq.Times.exactly(1));
 
@@ -765,9 +762,6 @@ describe('server/apollo.context', () => {
         req: {
           method: 'POST',
           path: '/PATH',
-        },
-        graphql: {
-          operations: [],
         },
       }))
       .verifiable(TypeMoq.Times.exactly(1));

--- a/src/server/apollo.context.ts
+++ b/src/server/apollo.context.ts
@@ -116,17 +116,20 @@ export function logContextRequest(context: Context): void {
     });
   }
 
-  telemetry.info('logContextRequest', {
+  const logged: Record<string, any> = {
     source: 'apollo',
     action: 'request',
     req: { // merged into { req } subcontext
       method,
       path,
     },
-    graphql: {
-      operations,
-    },
-  });
+  };
+  if (operations.length !== 0) {
+    logged.graphql = {
+      operations: JSON.stringify(operations),
+    };
+  }
+  telemetry.info('logContextRequest', logged);
 }
 
 export type InjectContextIntoRequestFactory = (constructorArgs: ContextConstructorArgs) => Context;


### PR DESCRIPTION
- too many CSV columns because of JSON parsing by Rapid7 / Datadog