### PR TITLE
ENG-2238 address CORS security RE: Cookie + Apollo GraphQL

### DIFF
--- a/src/middleware/defaults.ts
+++ b/src/middleware/defaults.ts
@@ -77,7 +77,7 @@ const MORGAN_LOGGER = morgan(_morganFormatter, {
 });
 
 
-const WITHJOY_DOMAIN_REGEX = /.withjoy.com$/;
+const WITHJOY_DOMAIN_REGEX = /\.withjoy\.com$/;
 
 export function getDefaultMiddleware(): DefaultMiddlewareResult {
   const preludesMap = new Map<string, RequestHandler>([

--- a/src/middleware/session.ts
+++ b/src/middleware/session.ts
@@ -27,16 +27,20 @@ export function generateSessionIdSetCookieHeaderValue(sessionId: string): string
   return cookie.serialize(SESSION_COOKIE_NAME, sessionId, {
     path: '/',
 
-    // (1) "a given Session ID can be used for both Staging & Production hosts" -- (2) make constant or relocate?
+    // "a given Session ID can be used for both Staging & Production hosts"
     domain: '.withjoy.com',
 
     httpOnly: true,
     expires: new Date(FAR_FUTURE_EXPIRES),  // for maximum compatibility with IE
     maxAge: FAR_FUTURE_MAX_AGE,             // for everything else
 
+    // don't enforce TLS (mostly for dev purposes)
+    secure: false,
+
     // it appears this is not necessary to share cookies from <subdm1>.withjoy.com:<portA> to <subdm2>.withjoy.com:<portB>
-    // seems wise to err on the side of reduced scope and expand later if necessary
-    //sameSite: 'none',
+    // end-to-end testing shows 'Lax' works well;
+    // we will not be shared as a third-party Cookie
+    sameSite: 'lax',
   });
 }
 

--- a/src/server/apollo.config.ts
+++ b/src/server/apollo.config.ts
@@ -267,6 +267,9 @@ export function deriveApolloEnvironmentConfig(args: ApolloEnvironmentConfigArgs)
       //   fortunately, { engine: false } neutralizes that concern
       engine: false,
       reporting: false,
+
+      // @see `getDefaultMiddleware`
+      cors: false,
     },
 
     engineReportingOptions: {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -126,7 +126,11 @@ export class Server implements IServer {
       this.app.use(path || '/graphql', ...apolloMiddleware);
     }
     apollo.applyMiddleware({
-      app: this.app
+      app: this.app,
+
+      // @see `getDefaultMiddleware`
+      //   also, legacy version; CORS disabled by #applyMiddleware
+      cors: false,
     });
   }
 }


### PR DESCRIPTION
- *we* are responsible for CORS middleware, not Apollo
- support legacy Apollo Config, rather than upgrade
- implemented & disabled strategy for strict 'withjoy.com'
- went with a generous Developer-centric strategy
- do not enforce TLS on Cookie (also Developer-centric)
- OK with 'Cookie:  SameSite=Lax', per end-to-end testing
- Cookies are issued & picked up via. GraphQL `withCredentials`!