### PR TITLE
ENG-2499 reconciled logging between `morgan` and `logContextRequest`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -655,6 +655,13 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/forwarded": {
+      "version": "0.1.0",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/fs-extra": {
       "version": "5.0.4",
       "requires": {
@@ -810,6 +817,9 @@
     "abab": {
       "version": "2.0.0",
       "dev": true
+    },
+    "abbrev": {
+      "version": "1.1.1"
     },
     "accepts": {
       "version": "1.3.5",
@@ -1476,6 +1486,16 @@
         "default-require-extensions": "^2.0.0"
       }
     },
+    "aproba": {
+      "version": "1.2.0"
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "requires": {
@@ -1915,6 +1935,9 @@
       "version": "1.0.2",
       "dev": true
     },
+    "chownr": {
+      "version": "1.1.1"
+    },
     "chroma-js": {
       "version": "2.0.4"
     },
@@ -2237,6 +2260,9 @@
     "concat-map": {
       "version": "0.0.1"
     },
+    "console-control-strings": {
+      "version": "1.1.0"
+    },
     "constant-case": {
       "version": "2.0.0",
       "requires": {
@@ -2385,6 +2411,9 @@
         }
       }
     },
+    "deep-extend": {
+      "version": "0.6.0"
+    },
     "deep-is": {
       "version": "0.1.3",
       "dev": true
@@ -2459,6 +2488,9 @@
     "delayed-stream": {
       "version": "1.0.0"
     },
+    "delegates": {
+      "version": "1.0.0"
+    },
     "depd": {
       "version": "1.1.2"
     },
@@ -2467,6 +2499,9 @@
     },
     "destroy": {
       "version": "1.0.4"
+    },
+    "detect-libc": {
+      "version": "1.0.3"
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -2879,6 +2914,12 @@
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "requires": {
+        "minipass": "^2.2.1"
       }
     },
     "fs.realpath": {
@@ -3480,6 +3521,41 @@
     "function-bind": {
       "version": "1.1.1"
     },
+    "gauge": {
+      "version": "2.7.4",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "gaze": {
       "version": "1.1.3",
       "requires": {
@@ -3688,6 +3764,9 @@
         "has-symbol-support-x": "^1.4.1"
       }
     },
+    "has-unicode": {
+      "version": "2.0.1"
+    },
     "has-value": {
       "version": "1.0.0",
       "dev": true,
@@ -3822,6 +3901,12 @@
     "ieee754": {
       "version": "1.1.12"
     },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "immer": {
       "version": "3.1.3"
     },
@@ -3859,6 +3944,9 @@
     },
     "inherits": {
       "version": "2.0.3"
+    },
+    "ini": {
+      "version": "1.3.5"
     },
     "interpret": {
       "version": "1.2.0"
@@ -5072,6 +5160,19 @@
     "minimist": {
       "version": "1.2.0"
     },
+    "minipass": {
+      "version": "2.3.5",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "mixin-deep": {
       "version": "1.3.1",
       "dev": true,
@@ -5199,6 +5300,31 @@
     "natural-orderby": {
       "version": "2.0.3"
     },
+    "needle": {
+      "version": "2.2.4",
+      "requires": {
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ms": {
+          "version": "2.0.0"
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.1"
     },
@@ -5315,6 +5441,27 @@
         "which": "^1.3.0"
       }
     },
+    "node-pre-gyp": {
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      }
+    },
+    "nopt": {
+      "version": "4.0.1",
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "dev": true,
@@ -5340,10 +5487,29 @@
         "sort-keys": "^2.0.0"
       }
     },
+    "npm-bundled": {
+      "version": "1.0.6"
+    },
+    "npm-packlist": {
+      "version": "1.3.0",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -5458,12 +5624,25 @@
         }
       }
     },
+    "os-homedir": {
+      "version": "1.0.2"
+    },
     "os-locale": {
       "version": "3.1.0",
       "requires": {
         "execa": "^1.0.0",
         "lcid": "^2.0.0",
         "mem": "^4.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2"
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-cancelable": {
@@ -5731,6 +5910,15 @@
         "unpipe": "1.0.0"
       }
     },
+    "rc": {
+      "version": "1.2.8",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "dev": true,
@@ -5967,7 +6155,6 @@
     },
     "rimraf": {
       "version": "2.6.3",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -6344,6 +6531,9 @@
     "strip-eof": {
       "version": "1.0.0"
     },
+    "strip-json-comments": {
+      "version": "2.0.1"
+    },
     "subscriptions-transport-ws": {
       "version": "0.9.15",
       "requires": {
@@ -6385,6 +6575,18 @@
     "symbol-tree": {
       "version": "3.2.2",
       "dev": true
+    },
+    "tar": {
+      "version": "4.4.8",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      }
     },
     "test-exclude": {
       "version": "5.1.0",
@@ -6862,6 +7064,12 @@
     },
     "which-module": {
       "version": "2.0.0"
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
     },
     "widest-line": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "cors": "2.8.5",
     "dataloader": "1.4.0",
     "express": "4.16.4",
+    "forwarded": "~0.1.2",
     "graphql": "^14.4.2",
     "graphql-tag": "^2.10.1",
     "immer": "^3.1.3",
@@ -65,6 +66,7 @@
   },
   "devDependencies": {
     "@types/chroma-js": "^1.4.1",
+    "@types/forwarded": "~0.1.0",
     "@types/lolex": "^3.1.1",
     "@types/moment-timezone": "^0.5.12",
     "@types/nock": "^10.0.2",

--- a/src/templates/model.template.ts
+++ b/src/templates/model.template.ts
@@ -1,4 +1,4 @@
- import { PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, VersionColumn, Column, Generated, Index } from 'typeorm';
+import { PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, VersionColumn, Column, Generated, Index } from 'typeorm';
 
 export abstract class ModelTemplate  {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,6 +492,13 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/forwarded@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/forwarded/-/forwarded-0.1.0.tgz#8191cf6f7c9934f3f6f75036d6f027a3dfcf1d94"
+  integrity sha512-bMAatSgDFLgJ9m+uqmGvRIeZojIZYJmFKkPT+TKFOORgMNgJrjaAnYfr464GDn2q98VKn7VhkxX2tsbO6Fvtig==
+  dependencies:
+    "@types/node" "*"
+
 "@types/fs-extra@^5.0.2":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.4.tgz#b971134d162cc0497d221adde3dbb67502225599"


### PR DESCRIPTION
- `sessionId` is important for log correlation
- `forwarded` properly derives a remote IP address
- `path` vs. `url`, and consider GraphQL middleware rewrites
- `host` = HTTP requested host (vs. physical `hostname`)