### PR TITLE
ENG-2539 prepare to upgrade Apollo tooling for `yarn schema:*` scripts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// also:  @see node6.ts
+
+import { VERSION } from './utils/const';
 import {
   Context,
   IContext,
@@ -85,6 +88,8 @@ import * as sortKeyBase64 from './utils/sortKey/base64';
 import * as sortKeyPaddedNumeric from './utils/sortKey/paddedNumeric';
 
 export {
+  VERSION,
+
   Context,
   IContext,
   ContextConstructorArgs,

--- a/src/node6.ts
+++ b/src/node6.ts
@@ -1,3 +1,4 @@
+import { VERSION } from './utils/const';
 import {
   sessionMiddleware,
   SESSION_COOKIE_NAME,
@@ -6,8 +7,9 @@ import {
 } from './middleware/session';
 
 export {
-  sessionMiddleware,
+  VERSION,
 
+  sessionMiddleware,
   SESSION_COOKIE_NAME,
   SESSION_HEADER_NAME,
   SESSION_REQUEST_PROPERTY,

--- a/src/server/apollo.config.spec.ts
+++ b/src/server/apollo.config.spec.ts
@@ -7,6 +7,7 @@ import {
 } from './apollo.config';
 
 
+const API_KEY = 'ENGINE_API_KEY';
 const DEFAULT_CONFIG_ARGS: ApolloEnvironmentConfigArgs = {
   serviceName: 'testSuite',
   servicePort: '90210',
@@ -19,7 +20,7 @@ describe('server/apollo.config', () => {
     env = Object.assign({}, process.env);
 
     // things everyone needs
-    process.env.ENGINE_API_KEY = 'ENGINE_API_KEY';
+    process.env.ENGINE_API_KEY = API_KEY;
   });
 
   afterEach(() => {
@@ -247,6 +248,123 @@ describe('server/apollo.config', () => {
             url: 'http://localhost:90210/graphql',
           },
         },
+      });
+    });
+
+
+    describe('per the variant', () => {
+      // for "less subtle" configuration sections not covered above
+
+      it('provides a local configuration', () => {
+        const config = deriveApolloEnvironmentConfig({
+          ...DEFAULT_CONFIG_ARGS,
+          variant: ApolloEnvironmentVariant.local,
+        });
+
+        expect(config).toMatchObject({
+          variant: ApolloEnvironmentVariant.local,
+
+          apiKey: API_KEY,
+          engineReportingOptions: {
+            apiKey: API_KEY,
+            schemaTag: 'development',
+          },
+          serverOptions: {
+            cors: false,
+            debug: true,
+            engine: false,
+            introspection: true,
+            mocks: false,
+            playground: true,
+            reporting: false,
+            subscriptions: false,
+            tracing: true,
+          },
+        });
+      });
+
+      it('provides a development configuration', () => {
+        const config = deriveApolloEnvironmentConfig({
+          ...DEFAULT_CONFIG_ARGS,
+          variant: ApolloEnvironmentVariant.development,
+        });
+
+        expect(config).toMatchObject({
+          variant: ApolloEnvironmentVariant.development,
+
+          apiKey: API_KEY,
+          engineReportingOptions: {
+            apiKey: API_KEY,
+            schemaTag: 'development',
+          },
+          serverOptions: {
+            cors: false,
+            debug: true,
+            engine: false,
+            introspection: true,
+            mocks: false,
+            playground: true,
+            reporting: false,
+            subscriptions: false,
+            tracing: true,
+          },
+        });
+      });
+
+      it('provides a staging configuration', () => {
+        const config = deriveApolloEnvironmentConfig({
+          ...DEFAULT_CONFIG_ARGS,
+          variant: ApolloEnvironmentVariant.staging,
+        });
+
+        expect(config).toMatchObject({
+          variant: ApolloEnvironmentVariant.staging,
+
+          apiKey: API_KEY,
+          engineReportingOptions: {
+            apiKey: API_KEY,
+            schemaTag: 'staging',
+          },
+          serverOptions: {
+            cors: false,
+            debug: true,
+            engine: false,
+            introspection: true,
+            mocks: false,
+            playground: true,
+            reporting: false,
+            subscriptions: false,
+            tracing: true,
+          },
+        });
+      });
+
+      it('provides a production configuration', () => {
+        const config = deriveApolloEnvironmentConfig({
+          ...DEFAULT_CONFIG_ARGS,
+          variant: ApolloEnvironmentVariant.production,
+        });
+
+        expect(config).toMatchObject({
+          variant: ApolloEnvironmentVariant.production,
+
+          apiKey: API_KEY,
+          engineReportingOptions: {
+            apiKey: API_KEY,
+            schemaTag: 'production',
+          },
+          serverOptions: {
+            cors: false,
+            debug: false,
+            engine: false,
+            introspection: true,
+            mocks: false,
+            playground: false,
+            reporting: false,
+            subscriptions: false,
+            tracing: true,
+          },
+        });
       });
     });
   });

--- a/src/server/apollo.context.spec.ts
+++ b/src/server/apollo.context.spec.ts
@@ -685,7 +685,7 @@ describe('server/apollo.context', () => {
       context = new Context({
         req: createRequest({
           // individual properties, vs. relying upon a parsed `url`
-          host: 'HOSTNAME',
+          hostname: 'HOSTNAME', // HTTP requested host (vs. physical hostname)
           method: 'POST',
           path: '/IGNORED',
           body: { query },
@@ -736,7 +736,7 @@ describe('server/apollo.context', () => {
     it('logs a REST-y GET request', () => {
       context = new Context({
         req: createRequest({
-          host: 'HOSTNAME',
+          hostname: 'HOSTNAME',
           method: 'GET',
           path: '/PATH',
           query: { param: true },
@@ -765,7 +765,7 @@ describe('server/apollo.context', () => {
     it('logs a REST-y POST request', () => {
       context = new Context({
         req: createRequest({
-          host: 'HOSTNAME',
+          hostname: 'HOSTNAME',
           method: 'POST',
           path: '/PATH',
           body: { param: true },
@@ -805,7 +805,7 @@ describe('server/apollo.context', () => {
     it('does not log a health check', () => {
       context = new Context({
         req: createRequest({
-          host: 'HOSTNAME',
+          hostname: 'HOSTNAME',
           method: 'GET',
           path: '/healthy',
         }),

--- a/src/server/apollo.context.ts
+++ b/src/server/apollo.context.ts
@@ -81,7 +81,7 @@ export function logContextRequest(context: Context): void {
   }
 
   const { telemetry, sessionId } = context;
-  const { host, method, body } = req;
+  const { hostname: host, method, body } = req;
   const path = (req.baseUrl || req.path); // GraphQL middleware does a rewrite
   if (path.startsWith('/healthy')) {
     // health checks should not spam the logs

--- a/src/server/server.init.ts
+++ b/src/server/server.init.ts
@@ -1,14 +1,16 @@
 import { telemetry, deriveTelemetryContextFromError } from '@withjoy/telemetry';
 
+import { VERSION } from '../utils/const';
 import { IServer } from './server';
 
 
 export const initApp = (app: IServer, port: number) => {
   let closeCalled = false;
-  const gracefulClose = (reason: string): Promise<void> => {
+  const gracefulClose = async (reason: string): Promise<void> => {
     telemetry.info('initApp', {
       action: 'starting',
       reason,
+      serverCoreVersion: VERSION,
     });
 
     if (closeCalled) {
@@ -31,6 +33,7 @@ export const initApp = (app: IServer, port: number) => {
         telemetry.info('initApp', {
           action: 'complete',
           reason,
+          serverCoreVersion: VERSION,
         });
       })
       .catch(err => {
@@ -38,13 +41,14 @@ export const initApp = (app: IServer, port: number) => {
           ...deriveTelemetryContextFromError(err),
           action: 'error',
           reason,
+          serverCoreVersion: VERSION,
         });
         throw err;
       });
   };
 
-  const gracefulRestart = (signalName: string) => {
-    gracefulClose(`${signalName}: Graceful restart`)
+  const gracefulRestart = async (signalName: string) => {
+    return gracefulClose(`${signalName}: Graceful restart`)
       .then(() => process.kill(process.pid, signalName))
       .catch(err => {
         telemetry.error('initApp.gracefulRestart', {
@@ -56,8 +60,8 @@ export const initApp = (app: IServer, port: number) => {
       });
   };
 
-  const gracefulShutdown = (signalName: string) => {
-    gracefulClose(`${signalName}: Graceful shutdown`)
+  const gracefulShutdown = async (signalName: string) => {
+    return gracefulClose(`${signalName}: Graceful shutdown`)
       .then(() => process.exit(0))
       .catch(err => {
         telemetry.error('initApp.gracefulShutdown', {
@@ -88,6 +92,7 @@ export const initApp = (app: IServer, port: number) => {
     .then(config => {
       telemetry.info('initApp', {
         action: 'started',
+        serverCoreVersion: VERSION,
         port: config.port,
       });
     })
@@ -95,6 +100,7 @@ export const initApp = (app: IServer, port: number) => {
       telemetry.error('initApp', {
         ...deriveTelemetryContextFromError(err),
         action: 'error',
+        serverCoreVersion: VERSION,
       });
       process.exit(1);
     });

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,0 +1,3 @@
+const packageJson = require(`${ __dirname }/../../package.json`);
+
+export const VERSION = packageJson.version;


### PR DESCRIPTION
- more ApolloEnvironmentConfig coverage before making changes
- simpler `serverOptions` logic
- "schemaTag" => "graphVariant" wherever possible
- support both future `APOLLO_KEY` and deprecated `ENGINE_API_KEY`
- FIXMEs for changes to be made after server-core Apollo upgrades
- "express deprecated req.host"
- log the server-core version upon Server startup

we are **not** taking on the across-the-board version upgrades right now

## warning messages

these were observed, and addressed as well as possible

```
[deprecated] The `ENGINE_API_KEY` environment variable has been renamed to `APOLLO_KEY`.

[deprecated] The `schemaTag` property within `engine` configuration has been renamed to `graphVariant`.

It looks like you're running a federated schema and you've configured your service to report metrics to Apollo Graph Manager. You should only configure your Apollo gateway to report metrics to Apollo Graph Manager.

A local gateway service list is overriding an Apollo Graph Manager managed configuration.  To use the managed configuration, do not specify a service list locally.

express deprecated req.host: Use req.hostname instead node_modules/@withjoy/server-core/dist/server/apollo.context.js:69:36
```
