### PR TITLE
VEN-312 always echo the `{ linkText }` when parsing a Virtual Event link

### DIFF
--- a/src/utils/virtualEvent/_helpers.ts
+++ b/src/utils/virtualEvent/_helpers.ts
@@ -9,10 +9,10 @@ import {
 import { omit } from 'lodash';
 
 export type _VirtualEventLinkParseFragment = {
-  urlLinkText: string;
+  urlLinkText?: string;
   urlApp?: string;
   urlBrowser?: string; // for Grandma
-  streamId: string;
+  streamId?: string;
   passwordDetected: boolean;
   passwordUrlEmbed?: string;
   passwordText?: string;

--- a/src/utils/virtualEvent/index.spec.ts
+++ b/src/utils/virtualEvent/index.spec.ts
@@ -11,9 +11,20 @@ describe('service/virtualEvent', () => {
     it('matches nothing', () => {
       chaiExpects( parseVirtualEventLink(<unknown>null as string) ).to.equal(null);
       chaiExpects( parseVirtualEventLink('') ).to.equal(null);
-      chaiExpects( parseVirtualEventLink('http-ish String') ).to.equal(null);
+    });
 
-      chaiExpects( parseVirtualEventLink('https://withjoy.com/meetjoy') ).to.equal(null);
+    it('matches text that it does not recognize', () => {
+      chaiExpects( parseVirtualEventLink('http-ish String') ).to.deep.equal({
+        provider: VirtualEventProvider.unknown,
+        linkText: 'http-ish String',
+        passwordDetected: false,
+      });
+
+      chaiExpects( parseVirtualEventLink('https://withjoy.com/meetjoy') ).to.deep.equal({
+        provider: VirtualEventProvider.unknown,
+        linkText: 'https://withjoy.com/meetjoy',
+        passwordDetected: false,
+      });
     });
 
     it('matches Zoom', () => {

--- a/src/utils/virtualEvent/index.ts
+++ b/src/utils/virtualEvent/index.ts
@@ -45,10 +45,16 @@ export {
 };
 
 export function parseVirtualEventLink(text: string): VirtualEventLinkParseResult | null {
-  let match: VirtualEventLinkParseResult | null = null;
   if (! text) {
-    return match;
+    return null;
   }
+
+  // assume unknown
+  let match: VirtualEventLinkParseResult = {
+    provider: VirtualEventProvider.unknown,
+    linkText: text,
+    passwordDetected: false,
+  };
 
   for (let { provider, parseLink } of PROVIDER_TOOLKITS) {
     const parsed = parseLink(text);

--- a/src/utils/virtualEvent/schema.ts
+++ b/src/utils/virtualEvent/schema.ts
@@ -14,6 +14,7 @@ export const markup = (options: {
 }): string => (`
 
   enum VirtualEventProvider {
+    unknown
     zoom
     youtube
     googleMeet
@@ -23,10 +24,10 @@ export const markup = (options: {
   type VirtualEventLinkParseResult {
     provider: VirtualEventProvider!
     linkText: String!
-    urlLinkText: String!
+    urlLinkText: String
     urlApp: String
     urlBrowser: String
-    streamId: String!
+    streamId: String
     passwordDetected: Boolean!
     passwordUrlEmbed: String
     passwordText: String

--- a/src/utils/virtualEvent/types.ts
+++ b/src/utils/virtualEvent/types.ts
@@ -5,6 +5,7 @@ import {
 
 // @public
 export enum VirtualEventProvider {
+  unknown = 'unknown',
   zoom = 'zoom',
   youtube = 'youtube',
   googleMeet = 'googleMeet',


### PR DESCRIPTION
- unless it's not present, in which case parse => `null`
- added VirtualEventProvider.unknown
- more optional properties, only available upon a valid parse