### PR TITLE
VEN-476 provide parseable timezone offset from CoreTypeDef `Date`

### DIFF
--- a/src/graphql/core.types.spec.ts
+++ b/src/graphql/core.types.spec.ts
@@ -1,16 +1,29 @@
 import {
+  Context,
+  createContext,
+} from '../server/apollo.context';
+import {
+  TimezoneFormat,
+  DateFormat,
+  TimeFormat,
+
   resolveCoreTypeDate,
   parseCoreTypeInputDate,
+  coreResolvers,
 } from './core.types';
 
-const DATE = new Date(1478676600500);
-const DATE_ISO = '2016-11-09T07:30:00.500Z';
-const TZ_IANA = 'America/Montreal'; // IANA code, aligns with locale = 'fr-CA'
+const EPOCH = 1478677500;
+const MILLIS = EPOCH * 1000;
+const DATE = new Date(MILLIS);
+const DATE_ISO = '2016-11-09T07:45:00.000Z';  // without offset
+const TZ_QUEBECOIS = 'America/Montreal'; // IANA code
+const LOCALE_QUEBECOIS = 'fr-CA'; // IETF code
+
 
 describe('graphql/core.types', () => {
   describe('resolveCoreTypeDate', () => {
     it('returns a coreTypeDef reference', () => {
-      expect(resolveCoreTypeDate(DATE, TZ_IANA)).toEqual([ DATE_ISO, TZ_IANA ]);
+      expect(resolveCoreTypeDate(DATE, TZ_QUEBECOIS)).toEqual([ DATE_ISO, TZ_QUEBECOIS ]);
     });
 
     it('returns a coreTypeDef reference without a timezone', () => {
@@ -19,9 +32,10 @@ describe('graphql/core.types', () => {
 
     it('returns no coreTypeDef reference without any useful information', () => {
       expect(resolveCoreTypeDate(undefined, undefined)).toBeNull();
-      expect(resolveCoreTypeDate(undefined, TZ_IANA)).toBeNull();
+      expect(resolveCoreTypeDate(undefined, TZ_QUEBECOIS)).toBeNull();
     });
   });
+
 
   describe('parseCoreTypeDateInput', () => {
     it('tolerates lack-of-input', () => {
@@ -31,7 +45,7 @@ describe('graphql/core.types', () => {
     });
 
     it('parses an ISO-8601 Date string', () => {
-      expect(parseCoreTypeInputDate(DATE_ISO)!.valueOf()).toBe(DATE.valueOf());
+      expect(parseCoreTypeInputDate(DATE_ISO)!.valueOf()).toBe(MILLIS);
     });
 
     it('fails to parse a non-ISO-8601 string', () => {
@@ -50,6 +64,260 @@ describe('graphql/core.types', () => {
       expect(() => {
         return parseCoreTypeInputDate(DATE.toLocaleString());
       }).toThrow(TypeError);
+    });
+  });
+
+
+  describe('coreResolvers', () => {
+    describe('Date', () => {
+      const DATE_AND_TZ = [ DATE_ISO, TZ_QUEBECOIS ];
+      const TZ_UTC = 'Etc/UTC';
+      const TZ_SAME_AS_GMT = 'Atlantic/Reykjavik';
+      const TZ_EARILER_THAN_GMT_NON_HOUR = 'Asia/Calcutta';
+      const INVALID_DATE = 'BAD';
+      const INVALID_DATE_AND_TZ = [ 'BAD', 'WORSE' ];
+      const INVALID_TZ = [ DATE_ISO, 'WORSE' ];
+      const resolver = coreResolvers.Date as any;
+
+      describe('#timestamp', () => {
+        it('resolves a CoreTypeDate as an ISO-8601 string', () => {
+          const asGMT = resolver.timestamp(DATE_ISO);
+          expect(asGMT).toBe('2016-11-09T07:45:00+00:00');
+          // it('resolves a parseable ISO-8601 string / can eat its own dogfood')
+          expect(parseCoreTypeInputDate(asGMT)!.valueOf()).toBe(MILLIS);
+
+          const withOffset = resolver.timestamp(DATE_AND_TZ);
+          expect(withOffset).toBe('2016-11-09T02:45:00-05:00');
+          expect(parseCoreTypeInputDate(withOffset)!.valueOf()).toBe(MILLIS);
+        });
+
+        it('resolves one-second precision', () => {
+          const halfSecondLater = MILLIS + 500;
+          const withMilliPrecision = new Date(halfSecondLater).toISOString();
+          const withSecondPrecision = resolver.timestamp(withMilliPrecision);
+          expect(withSecondPrecision).toBe('2016-11-09T07:45:00+00:00');
+
+          const dogfood = new Date(withSecondPrecision).valueOf();
+          expect(dogfood).toBe(MILLIS);
+          expect(dogfood + 500).toBe(halfSecondLater);
+        });
+
+        it('resolves its timezone offset as a parseable representation', () => {
+          expect(resolver.timestamp(DATE_ISO).endsWith('+00:00')).toBe(true);
+          expect(resolver.timestamp(DATE_AND_TZ).endsWith('-05:00')).toBe(true);
+
+          // it('resolves the offset for a GMT+00:00 timezone which is *not* Etc/UTC')
+          expect(resolver.timestamp([ DATE_ISO, TZ_SAME_AS_GMT ]).endsWith('+00:00')).toBe(true);
+
+          // it('resolves the offset for a timezone earlier than GMT and not aligned to the hour')
+          expect(resolver.timestamp([ DATE_ISO, TZ_EARILER_THAN_GMT_NON_HOUR ]).endsWith('+05:30')).toBe(true);
+        });
+
+        it('falls back to the Epoch for an unparseable Date', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.timestamp(INVALID_DATE)).toBe('1970-01-01T00:00:00+00:00');
+          expect(resolver.timestamp(INVALID_DATE_AND_TZ)).toBe('1970-01-01T00:00:00+00:00');
+        });
+
+        it('falls back to GMT for an invalid timezone', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.timestamp(INVALID_TZ)).toBe('2016-11-09T07:45:00+00:00');
+        });
+      });
+
+      describe('#timezone', () => {
+        const ARGS_LONG = { format: TimezoneFormat.long };
+        const ARGS_SHORT = { format: TimezoneFormat.short };
+
+        it('resolves the timezone provided', () => {
+          expect(resolver.timezone(DATE_AND_TZ, ARGS_LONG)).toBe(TZ_QUEBECOIS);
+          expect(resolver.timezone(DATE_AND_TZ, ARGS_SHORT)).toBe('EST');
+
+          expect(resolver.timezone([ DATE_ISO, TZ_UTC ], ARGS_LONG)).toBe(TZ_UTC);
+          expect(resolver.timezone([ DATE_ISO, TZ_UTC ], ARGS_SHORT)).toBe('UTC');
+
+          expect(resolver.timezone([ DATE_ISO, TZ_SAME_AS_GMT ], ARGS_LONG)).toBe(TZ_SAME_AS_GMT);
+          expect(resolver.timezone([ DATE_ISO, TZ_SAME_AS_GMT ], ARGS_SHORT)).toBe('GMT');
+
+          expect(resolver.timezone([ DATE_ISO, TZ_EARILER_THAN_GMT_NON_HOUR ], ARGS_LONG)).toBe(TZ_EARILER_THAN_GMT_NON_HOUR);
+          expect(resolver.timezone([ DATE_ISO, TZ_EARILER_THAN_GMT_NON_HOUR ], ARGS_SHORT)).toBe('IST');
+        });
+
+        it('falls back to UTC in the absence of a timezone', () => {
+          expect(resolver.timezone(DATE_ISO, ARGS_LONG)).toBe(TZ_UTC);
+          expect(resolver.timezone(DATE_ISO, ARGS_SHORT)).toBe('UTC');
+        });
+
+        it('falls back to the Epoch for an unparseable Date', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.timezone(INVALID_DATE, ARGS_LONG)).toBe(TZ_UTC);
+          expect(resolver.timezone(INVALID_DATE_AND_TZ, ARGS_LONG)).toBe(TZ_UTC);
+        });
+
+        it('falls back to GMT for an invalid timezone', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.timezone(INVALID_TZ, ARGS_LONG)).toBe(TZ_UTC);
+        });
+      });
+
+/*
+      // TODO
+      //   @see ENG-746 is it safe for us to change "core" Enums
+
+      describe('#utcOffset', () => {
+        it('resolves the offset for the timezone provided', () => {
+          expect(resolver.utcOffset(DATE_AND_TZ)).toBe(-300);
+          expect(resolver.utcOffset([ DATE_ISO, TZ_UTC ])).toBe(0);
+          expect(resolver.utcOffset([ DATE_ISO, TZ_SAME_AS_GMT ])).toBe(0);
+          expect(resolver.utcOffset([ DATE_ISO, TZ_EARILER_THAN_GMT_NON_HOUR ])).toBe(+330);
+        });
+
+        it('falls back to UTC in the absence of a timezone', () => {
+          expect(resolver.utcOffset(DATE_ISO)).toBe(0);
+        });
+
+        it('falls back to the Epoch for an unparseable Date', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.utcOffset(INVALID_DATE)).toBe(0);
+          expect(resolver.utcOffset(INVALID_DATE_AND_TZ)).toBe(0);
+        });
+
+        it('falls back to GMT for an invalid timezone', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.utcOffset(INVALID_TZ)).toBe(0);
+        });
+      });
+*/
+
+      describe('#unixTimestamp', () => {
+        it('resolves the Unix epoch / number of seconds elapsed since 1970-01-01', () => {
+          expect(resolver.unixTimestamp(DATE_ISO)).toBe(EPOCH);
+          expect(resolver.unixTimestamp(DATE_AND_TZ)).toBe(EPOCH);
+        });
+
+        it('falls back to the Epoch for an unparseable Date', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.unixTimestamp(INVALID_DATE)).toBe(0);
+          expect(resolver.unixTimestamp(INVALID_DATE_AND_TZ)).toBe(0);
+        });
+
+        it('falls back to GMT for an invalid timezone', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.unixTimestamp(INVALID_TZ)).toBe(EPOCH);
+        });
+      });
+
+      describe('#milliseconds', () => {
+        it('resolves the number of milliseconds elapsed since 1970-01-01', () => {
+          expect(resolver.milliseconds(DATE_ISO)).toBe(MILLIS);
+          expect(resolver.milliseconds(DATE_AND_TZ)).toBe(MILLIS);
+        });
+
+        it('falls back to the Epoch for an unparseable Date', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.milliseconds(INVALID_DATE)).toBe(0);
+          expect(resolver.milliseconds(INVALID_DATE_AND_TZ)).toBe(0);
+        });
+
+        it('falls back to GMT for an invalid timezone', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.milliseconds(INVALID_TZ)).toBe(MILLIS);
+        });
+      });
+
+      describe('#dateString', () => {
+        const CONTEXT = createContext() as Context;
+        expect(CONTEXT.locale).toBe('en_US');
+
+        const ARGS_FALLBACK = {};
+        const ARGS_DATE_SHORT = { dateFormat: DateFormat.short };
+        const ARGS_TIME_SECONDS = { timeFormat: TimeFormat.timeWithSeconds };
+        const ARGS_DATE_SHORT_TIME_SECONDS = { ...ARGS_DATE_SHORT, ...ARGS_TIME_SECONDS };
+
+        it('falls back to the the full format', () => {
+          expect(resolver.dateString(DATE_ISO, ARGS_FALLBACK, CONTEXT)).toBe('Wednesday, November 9, 2016 7:45 AM');
+          expect(resolver.dateString(DATE_AND_TZ, ARGS_FALLBACK, CONTEXT)).toBe('Wednesday, November 9, 2016 2:45 AM');
+        });
+
+        it('resolves a specified Date format', () => {
+          expect(resolver.dateString(DATE_ISO, ARGS_DATE_SHORT, CONTEXT)).toBe('Nov 9, 2016');
+          expect(resolver.dateString(DATE_AND_TZ, ARGS_DATE_SHORT, CONTEXT)).toBe('Nov 9, 2016');
+        });
+
+        it('resolves a specified Time format', () => {
+          expect(resolver.dateString(DATE_ISO, ARGS_TIME_SECONDS, CONTEXT)).toBe('7:45:00 AM');
+          expect(resolver.dateString(DATE_AND_TZ, ARGS_TIME_SECONDS, CONTEXT)).toBe('2:45:00 AM');
+        });
+
+        it('resolves a specified Date + Time format', () => {
+          expect(resolver.dateString(DATE_ISO, ARGS_DATE_SHORT_TIME_SECONDS, CONTEXT)).toBe('Nov 9, 2016 7:45:00 AM');
+          expect(resolver.dateString(DATE_AND_TZ, ARGS_DATE_SHORT_TIME_SECONDS, CONTEXT)).toBe('Nov 9, 2016 2:45:00 AM');
+        });
+
+        it('leverages the Context locale', () => {
+          const QUEBECOIS = createContext({ locale: LOCALE_QUEBECOIS });
+
+          expect(resolver.dateString(DATE_AND_TZ, ARGS_FALLBACK, QUEBECOIS)).toBe('mercredi 9 novembre 2016 02:45');
+          expect(resolver.dateString(DATE_AND_TZ, ARGS_DATE_SHORT, QUEBECOIS)).toBe('9 nov. 2016');
+          expect(resolver.dateString(DATE_AND_TZ, ARGS_TIME_SECONDS, QUEBECOIS)).toBe('02:45:00');
+          expect(resolver.dateString(DATE_AND_TZ, ARGS_DATE_SHORT_TIME_SECONDS, QUEBECOIS)).toBe('9 nov. 2016 02:45:00');
+        });
+
+        it('falls back to the Epoch for an unparseable Date', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.dateString(INVALID_DATE, ARGS_FALLBACK, CONTEXT)).toBe('Thursday, January 1, 1970 12:00 AM');
+          expect(resolver.dateString(INVALID_DATE_AND_TZ, ARGS_FALLBACK, CONTEXT)).toBe('Thursday, January 1, 1970 12:00 AM');
+        });
+
+        it('falls back to GMT for an invalid timezone', () => {
+          // ... which may or may not be appropriate
+          expect(resolver.dateString(INVALID_TZ, ARGS_FALLBACK, CONTEXT)).toBe('Wednesday, November 9, 2016 7:45 AM');
+        });
+      });
+    });
+
+
+    describe('Color', () => {
+      // PANTONE 17-1937 TCX Hot Pink
+      const COLOR_HEX = '#e55982';
+      const COLOR_NUMERIC = 0xE55982;
+      const COLOR_RGBA = [ 229, 89, 130, 1 ];
+      const resolver = coreResolvers.Color as any;
+
+      describe('#hex', () => {
+        it('resolves the hex value of a Color', () => {
+          expect(resolver.hex(COLOR_HEX)).toBe(COLOR_HEX);
+          expect(resolver.hex(COLOR_NUMERIC)).toBe(COLOR_HEX);
+        });
+
+        it('falls back to black for an invalid Color', () => {
+          expect(resolver.hex('INVALID')).toBe('#000000');
+        });
+      });
+
+      describe('#rgba', () => {
+        it('resolves the RGBA values of a Color', () => {
+          expect(resolver.rgba(COLOR_HEX)).toEqual(COLOR_RGBA);
+          expect(resolver.rgba(COLOR_NUMERIC)).toEqual(COLOR_RGBA);
+        });
+
+        it('falls back to black for an invalid Color', () => {
+          expect(resolver.rgba('INVALID')).toEqual([ 0, 0, 0, 1 ]);
+        });
+      });
+
+      describe('#isLight', () => {
+        it('resolves true for a light Color', () => {
+          expect(resolver.isLight(COLOR_HEX)).toBe(false);
+
+          expect(resolver.isLight('#000')).toBe(false);
+          expect(resolver.isLight('#fff')).toBe(true);
+        });
+
+        it('falls back to black for an invalid Color', () => {
+          expect(resolver.isLight('INVALID')).toBe(false);
+        });
+      });
     });
   });
 });

--- a/src/graphql/core.types.ts
+++ b/src/graphql/core.types.ts
@@ -1,10 +1,11 @@
 import { gql, IResolvers } from 'apollo-server';
 import moment, { Moment } from 'moment-timezone';
-import chroma from 'chroma-js';
+import chroma, { Color } from 'chroma-js';
 import { Context } from 'src/server/apollo.context';
 
 const UTC_LONG = 'Etc/UTC';
 const UTC_SHORT = 'UTC';
+const FORMAT_TIMESTAMP = 'YYYY-MM-DD[T]HH:mm:ssZ'; // ISO-8601, with '+00:00' (vs. 'Z') for GMT
 
 export const coreTypeDefs = gql`
 
@@ -57,12 +58,18 @@ export const coreTypeDefs = gql`
     timeWithSeconds
   }
 
-  "An ISO-8601 timestamp"
+  "An ISO-8601 timestamp, with one-second precision, expressing its timezone offset"
   scalar Timestamp
 
   type Date {
     dateString(dateFormat: DateFormat, timeFormat: TimeFormat): String!
+    "The timezone name"
     timezone(format: TimezoneFormat): String!
+    # # TODO:  expose 'utcOffset'
+    # #   @see ENG-746 is it safe for us to change "core" Enums
+    # "The timezone offset from UTC, in minutes"
+    # utcOffset: Int!
+    "An ISO-8601 timestamp"
     timestamp: Timestamp!
     "A Unix timestamp / epoch"
     unixTimestamp: Int!
@@ -72,32 +79,52 @@ export const coreTypeDefs = gql`
 
 `;
 
-const convertDate = (date: string | [string, string]): Moment => {
-  if (Array.isArray(date)) {
-    return moment.tz(date[0], date[1]);
-  } else {
-    return moment.tz(date, UTC_LONG);
+
+type _CoreTypeDateTuple = [ string, string ] | string;
+
+const _FALLBACK_DATE = moment(0).tz(UTC_LONG);
+function _convertDateTupleToMoment(dateTuple: _CoreTypeDateTuple): Moment {
+  let converted;
+
+  if (Array.isArray(dateTuple)) { // has a timezone
+    const date = dateTuple[0];
+    let timezone = dateTuple[1] || UTC_LONG; // empty-String protection
+
+    if (! moment.tz.zone(timezone)) {
+      // // resolve UTC (vs. throw) when parsing an invalid timezone
+      // //   unlike ISO-8601 strings, they're "volatile"; could change, be deprecated, etc.
+      // //   or worst of all, may already be invalid in pre-existing Customer data.
+      // throw new TypeError(`Invalid timezone: ${ JSON.stringify(coreTypeDate) }`);
+      timezone = UTC_LONG;
+    }
+
+    converted = moment.tz(date, timezone);
+  }
+  else { // Date-only => fall back to UTC
+    converted = moment.tz(dateTuple, UTC_LONG);
+  }
+
+  if (! converted.isValid()) {
+    // // resolve the Epoch / "Day 0" (vs. throw) when parsing an invalid Date
+    // //   minimum impact on the overall Graph result,
+    // //   since the Date may already be invalid in pre-existing Customer data.
+    // throw new TypeError(`Invalid date: ${ JSON.stringify(dateTuple) }`);
+    return _FALLBACK_DATE;
+  }
+  return converted;
+}
+
+const _FALLBACK_COLOR = chroma(0);
+function _convertColorToChroma(color: string | number): Color {
+  try {
+    return chroma(color);
+  }
+  catch (error) {
+    return _FALLBACK_COLOR;
   }
 }
 
-enum TimezoneFormat {
-  long = 'long',
-  short = 'short',
-}
-
-enum DateFormat {
-  numerical = 'numerical',
-  short = 'short',
-  long = 'long',
-  full = 'full',
-}
-
-enum TimeFormat {
-  time = 'time',
-  timeWithSeconds = 'timeWithSeconds',
-}
-
-const convertEnumToMomentFormat = (format?: DateFormat | TimeFormat) => {
+function _convertEnumToMomentFormat(format?: DateFormat | TimeFormat) {
   switch (format) {
     case TimeFormat.time: return 'LT';
     case TimeFormat.timeWithSeconds: return 'LTS';
@@ -109,7 +136,25 @@ const convertEnumToMomentFormat = (format?: DateFormat | TimeFormat) => {
   }
 }
 
-export type CoreTypeDate = [ string, string ] | string | null;
+
+export type CoreTypeDate = _CoreTypeDateTuple | null;
+
+export enum TimezoneFormat {
+  long = 'long',
+  short = 'short',
+}
+
+export enum DateFormat {
+  numerical = 'numerical',
+  short = 'short',
+  long = 'long',
+  full = 'full',
+}
+
+export enum TimeFormat {
+  time = 'time',
+  timeWithSeconds = 'timeWithSeconds',
+}
 
 export function resolveCoreTypeDate(date: Date | undefined, timezone?: string): CoreTypeDate {
   if (date) {
@@ -132,33 +177,40 @@ export function parseCoreTypeInputDate(input: string | null | undefined): Date |
   return parsed.toDate();
 }
 
+
 export const coreResolvers: IResolvers = {
   Date: {
-    timestamp: (date: string | [string, string]) => {
-      const convertedDate = convertDate(date);
-      return convertedDate.toISOString();
+    timestamp: (date: _CoreTypeDateTuple): string => {
+      const convertedDate = _convertDateTupleToMoment(date);
+      return convertedDate.format(FORMAT_TIMESTAMP); // @see `scalar Timestamp`
     },
-    timezone:(date: string | [string, string], args: { format: TimezoneFormat }) => {
+    timezone: (date: _CoreTypeDateTuple, args: { format: TimezoneFormat }): string => {
       const { format } = args;
-      const convertedDate = convertDate(date);
+      const convertedDate = _convertDateTupleToMoment(date);
       if (format === TimezoneFormat.short) {
         return convertedDate.zoneAbbr() || UTC_SHORT;
       } else {
         return convertedDate.tz() || UTC_LONG;
       }
     },
-    unixTimestamp: (date: string | [string, string]) => {
-      const convertedDate = convertDate(date);
+    // // TODO:  expose 'utcOffset'
+    // //   @see ENG-746 is it safe for us to change "core" Enums
+    // utcOffset: (date: _CoreTypeDateTuple): number => {
+    //   const convertedDate = _convertDateTupleToMoment(date);
+    //   return convertedDate.utcOffset();
+    // },
+    unixTimestamp: (date: _CoreTypeDateTuple): number => {
+      const convertedDate = _convertDateTupleToMoment(date);
       return convertedDate.unix();
     },
-    milliseconds: (date: string | [string, string]) => {
-      const convertedDate = convertDate(date);
+    milliseconds: (date: _CoreTypeDateTuple): number => {
+      const convertedDate = _convertDateTupleToMoment(date);
       return convertedDate.valueOf();
     },
-    dateString: (date: string | [string, string], args: { dateFormat?: DateFormat, timeFormat?: TimeFormat }, context: Context) => {
-      const convertedDate = convertDate(date);
-      const dateFormat = convertEnumToMomentFormat(args.dateFormat)
-      const timeFormat = convertEnumToMomentFormat(args.timeFormat)
+    dateString: (date: _CoreTypeDateTuple, args: { dateFormat?: DateFormat, timeFormat?: TimeFormat }, context: Context): string => {
+      const convertedDate = _convertDateTupleToMoment(date);
+      const dateFormat = _convertEnumToMomentFormat(args.dateFormat)
+      const timeFormat = _convertEnumToMomentFormat(args.timeFormat)
       if (dateFormat && timeFormat) {
         return convertedDate.locale(context.locale).format(dateFormat) + ' ' + convertedDate.locale(context.locale).format(timeFormat);
       } else if (dateFormat) {
@@ -166,20 +218,21 @@ export const coreResolvers: IResolvers = {
       } else if (timeFormat) {
         return convertedDate.locale(context.locale).format(timeFormat);
       } else {
-        const full = convertEnumToMomentFormat(DateFormat.full);
+        const full = _convertEnumToMomentFormat(DateFormat.full);
         return convertedDate.locale(context.locale).format(full);
       }
     },
   },
   Color: {
-    hex: (color) => {
-      return chroma(color).hex();;
+    hex: (color: string | number): string => {
+      return _convertColorToChroma(color).hex();
     },
-    rgba: (color) => {
-      return chroma(color).rgba();
+    rgba: (color: string | number): Array<number> => {
+      return _convertColorToChroma(color).rgba();
     },
-    isLight: (color) => {
-      return (chroma.distance('#fff', color) < 50);
+    isLight: (color: string | number): boolean => {
+      const converted = _convertColorToChroma(color);
+      return (chroma.distance('#fff', converted) < 50);
     }
   }
 }

--- a/src/server/apollo.context.ts
+++ b/src/server/apollo.context.ts
@@ -185,10 +185,10 @@ export interface ContextConstructorArgs {
   req?: Request;
   token?: string;
   userId?: string;
+  locale?: string;
   identityUrl?: string;
   identityCache?: Cache | null; // `null` to disable
   identityCacheTtl?: number;
-  locale?: string;
 }
 
 export class Context

--- a/test/apollo/core.types.color.ts
+++ b/test/apollo/core.types.color.ts
@@ -12,7 +12,7 @@ describe('the GraphQL Color TypeDefs', () => {
   let client: { query: Function };
 
 
-  beforeEach(async () => {
+  it('resolves a payload', async () => {
     const setup = await testSetupApollo({
       typeDefs: [
         coreTypeDefs,
@@ -26,16 +26,12 @@ describe('the GraphQL Color TypeDefs', () => {
         ...coreResolvers,
 
         Query: {
-          // just the Date string; no timezone specified
           color: () => COLOR_HEX,
         },
       },
     });
     client = setup.client;
-  });
 
-
-  it('formats the Color', async () => {
     const { query } = client;
     const res = await query({
       query: gql`
@@ -54,6 +50,50 @@ describe('the GraphQL Color TypeDefs', () => {
       color: {
         hex: '#e55982',
         rgba: [ 229, 89, 130, 1 ],
+        isLight: false,
+      },
+    });
+  });
+
+
+  it('resolves a payload for crappy data', async () => {
+    const setup = await testSetupApollo({
+      typeDefs: [
+        coreTypeDefs,
+        gql`
+          type Query {
+            color: Color!
+          }
+        `,
+      ],
+      resolvers: {
+        ...coreResolvers,
+
+        Query: {
+          color: () => 'CRAPPY',
+        },
+      },
+    });
+    client = setup.client;
+
+    const { query } = client;
+    const res = await query({
+      query: gql`
+        query {
+          color {
+            hex
+            rgba
+            isLight
+          }
+        }
+      `
+    });
+
+    const { data } = res;
+    expect(data).toMatchObject({
+      color: {
+        hex: '#000000',
+        rgba: [ 0, 0, 0, 1 ],
         isLight: false,
       },
     });


### PR DESCRIPTION
- `{ timestamp }` is still ISO-8601, and always provides "[+-]HH:MM"
- formal TypeScript-ing of Resolver methods
- expanded Unit Testing, better scenario coverage
- simplified GraphQL end-to-end Date testing

And while I was at it,

- implemented `{ utcOffset }` but can't release it; ENG-746 deployment risks
- formal handling of parse Errors for Color, Date + timezone