### PR TITLE
VEN-476 Virtual Event parsing fixes

### DIFF
--- a/src/utils/virtualEvent/_helpers.ts
+++ b/src/utils/virtualEvent/_helpers.ts
@@ -10,6 +10,7 @@ import { omit } from 'lodash';
 // `url-regexp` is not TypeScript'd
 const URLRegExp = require('url-regexp');
 
+
 export type _VirtualEventLinkParseFragment = {
   urlLinkText?: string;
   urlApp?: string;
@@ -22,6 +23,8 @@ export type _VirtualEventLinkParseFragment = {
 
 export type _VirtualEventLinkParser = (text: string) => _VirtualEventLinkParseFragment | null;
 
+
+export const _PATH_DELIMITER = '/';
 
 export function _deriveUrlLinkText(text: string): string | null {
   try {

--- a/src/utils/virtualEvent/aggregator.spec.ts
+++ b/src/utils/virtualEvent/aggregator.spec.ts
@@ -1,20 +1,20 @@
 import { expect as chaiExpects } from 'chai';
 
+import { VirtualEventProvider } from './types';
 import {
-  VirtualEventProvider,
-  parseVirtualEventLink,
-} from './index';
+  parseLink,
+} from './aggregator';
 
 
-describe('service/virtualEvent', () => {
-  describe('parseVirtualEventLink', () => {
+describe('service/virtualEvent/aggregator', () => {
+  describe('parseLink', () => {
     it('cannot match a lack-of-text', () => {
-      chaiExpects( parseVirtualEventLink(<unknown>null as string) ).to.equal(null);
-      chaiExpects( parseVirtualEventLink('') ).to.equal(null);
+      chaiExpects( parseLink(<unknown>null as string) ).to.equal(null);
+      chaiExpects( parseLink('') ).to.equal(null);
     });
 
     it('matches text without a URL', () => {
-      chaiExpects( parseVirtualEventLink('http-ish String') ).to.deep.equal({
+      chaiExpects( parseLink('http-ish String') ).to.deep.equal({
         provider: VirtualEventProvider.unknown,
         linkText: 'http-ish String',
         isLinkValid: false,
@@ -22,7 +22,7 @@ describe('service/virtualEvent', () => {
       });
 
       // it('even matches minimal whitespace')
-      chaiExpects( parseVirtualEventLink(' ') ).to.deep.equal({
+      chaiExpects( parseLink(' ') ).to.deep.equal({
         provider: VirtualEventProvider.unknown,
         linkText: ' ',
         isLinkValid: false,
@@ -33,13 +33,13 @@ describe('service/virtualEvent', () => {
     it('matches Zoom', () => {
       const TEXT = 'https://zoom.us/j/4155551212?pwd=P4s5w0r6';
 
-      chaiExpects( parseVirtualEventLink(TEXT) ).to.deep.equal({
+      chaiExpects( parseLink(TEXT) ).to.deep.equal({
         provider: VirtualEventProvider.zoom,
         linkText: TEXT,
         isLinkValid: true,
         urlLinkText: TEXT,
         urlApp: TEXT,
-        urlBrowser: 'https://zoom.us/wc/4155551212?pwd=P4s5w0r6',
+        urlBrowser: 'https://zoom.us/wc/join/4155551212?pwd=P4s5w0r6',
         streamId: '4155551212',
         isPasswordDetected: true,
         passwordUrlEmbed: 'P4s5w0r6',
@@ -50,7 +50,7 @@ describe('service/virtualEvent', () => {
     it('matches YouTube', () => {
       const TEXT = 'https://youtube.com/watch?v=dQw4w9WgXcQ&t=43';
 
-      chaiExpects( parseVirtualEventLink(TEXT) ).to.deep.equal({
+      chaiExpects( parseLink(TEXT) ).to.deep.equal({
         provider: VirtualEventProvider.youtube,
         linkText: TEXT,
         isLinkValid: true,
@@ -63,7 +63,7 @@ describe('service/virtualEvent', () => {
     it('matches Google Meet', () => {
       const TEXT = 'https://meet.google.com/thr-four-ee3';
 
-      chaiExpects( parseVirtualEventLink(TEXT) ).to.deep.equal({
+      chaiExpects( parseLink(TEXT) ).to.deep.equal({
         provider: VirtualEventProvider.googleMeet,
         linkText: TEXT,
         isLinkValid: true,
@@ -76,12 +76,12 @@ describe('service/virtualEvent', () => {
     it('matches EventLive', () => {
       const TEXT = 'https://evt.live/ACCOUNT/STREAM';
 
-      chaiExpects( parseVirtualEventLink(TEXT) ).to.deep.equal({
+      chaiExpects( parseLink(TEXT) ).to.deep.equal({
         provider: VirtualEventProvider.eventlive,
         linkText: TEXT,
         isLinkValid: true,
         urlLinkText: TEXT,
-        streamId: 'ACCOUNT/STREAM',
+        streamId: 'STREAM',
         isPasswordDetected: false,
       });
     });
@@ -89,7 +89,7 @@ describe('service/virtualEvent', () => {
     it('matches an unknown Provider', () => {
       const TEXT = 'https://withjoy.com/meetjoy';
 
-      chaiExpects( parseVirtualEventLink(TEXT) ).to.deep.equal({
+      chaiExpects( parseLink(TEXT) ).to.deep.equal({
         provider: VirtualEventProvider.unknown,
         linkText: TEXT,
         urlLinkText: TEXT,

--- a/src/utils/virtualEvent/aggregator.ts
+++ b/src/utils/virtualEvent/aggregator.ts
@@ -1,0 +1,72 @@
+import {
+  VirtualEventProvider,
+  VirtualEventLinkParseResult,
+} from './types';
+import {
+  _VirtualEventLinkParser,
+} from './_helpers';
+import { parseLink as parseZoomUrl } from './zoom';
+import { parseLink as parseYouTubeUrl } from './youtube';
+import { parseLink as parseGoogleMeetUrl } from './googleMeet';
+import { parseLink as parseEventLiveUrl } from './eventlive';
+import { parseLink as parseUnknownUrl } from './unknown';
+
+
+type _VirtualEventLinkProviderToolkit = {
+  provider: VirtualEventProvider,
+  parseLink: _VirtualEventLinkParser,
+};
+const PROVIDER_TOOLKITS: Array<_VirtualEventLinkProviderToolkit> = [
+  {
+    provider: VirtualEventProvider.zoom,
+    parseLink: parseZoomUrl,
+  },
+  {
+    provider: VirtualEventProvider.youtube,
+    parseLink: parseYouTubeUrl,
+  },
+  {
+    provider: VirtualEventProvider.googleMeet,
+    parseLink: parseGoogleMeetUrl,
+  },
+  {
+    provider: VirtualEventProvider.eventlive,
+    parseLink: parseEventLiveUrl,
+  },
+  // always last
+  {
+    provider: VirtualEventProvider.unknown,
+    parseLink: parseUnknownUrl,
+  },
+];
+
+
+// @public
+export function parseLink(linkText: string): VirtualEventLinkParseResult | null {
+  if (! linkText) {
+    return null;
+  }
+
+  for (let { provider, parseLink } of PROVIDER_TOOLKITS) {
+    const parsed = parseLink(linkText);
+    if (parsed) {
+      return {
+        provider,
+        linkText,
+        isLinkValid: true,
+
+        ...parsed,
+      };
+    }
+  }
+
+  // whatever the Couple cut-and-pasted to us, we echo back;
+  //   no known Provider
+  //   we detected nothing useful
+  return {
+    provider: VirtualEventProvider.unknown,
+    linkText,
+    isLinkValid: false,
+    isPasswordDetected: false,
+  };
+}

--- a/src/utils/virtualEvent/eventlive.spec.ts
+++ b/src/utils/virtualEvent/eventlive.spec.ts
@@ -21,32 +21,53 @@ describe('service/virtualEvent/eventlive', () => {
     });
 
 
-    describe('from a URL', () => {
+    describe('from a Viewer URL', () => {
       const URL = 'https://evt.live/ACCOUNT/STREAM';
 
       it('parses a URL', () => {
         chaiExpects( parseLink(URL) ).to.deep.equal({
           urlLinkText: URL,
-          streamId: 'ACCOUNT/STREAM',
+          streamId: 'STREAM',
           isPasswordDetected: false,
         });
 
         // it('honors sub-domains')
         chaiExpects( parseLink('https://my.evt.live/ACCOUNT/STREAM') ).to.include({
-          streamId: 'ACCOUNT/STREAM',
+          streamId: 'STREAM',
         });
 
         // it('honors more extenstive pathnames')
         //   https://broadcaster.eventlive.pro/event/<STREAM>/embed
         chaiExpects( parseLink('https://my.evt.live/ACCOUNT/STREAM/embed') ).to.include({
-          streamId: 'ACCOUNT/STREAM',
+          streamId: 'STREAM',
         });
       });
 
       it('derives a URL from anywhere within the text', () => {
         chaiExpects( parseLink(`Link Text: ${ URL }`) ).to.deep.equal({
           urlLinkText: URL,
-          streamId: 'ACCOUNT/STREAM',
+          streamId: 'STREAM',
+          isPasswordDetected: false,
+        });
+      });
+    });
+
+
+    describe('from a Broadcaster URL', () => {
+      const URL = 'https://broadcaster.eventlive.pro/event/STREAM';
+
+      it('parses a URL', () => {
+        chaiExpects( parseLink(URL) ).to.deep.equal({
+          urlLinkText: URL,
+          streamId: 'STREAM',
+          isPasswordDetected: false,
+        });
+      });
+
+      it('derives a URL from anywhere within the text', () => {
+        chaiExpects( parseLink(`Link Text: ${ URL }`) ).to.deep.equal({
+          urlLinkText: URL,
+          streamId: 'STREAM',
           isPasswordDetected: false,
         });
       });

--- a/src/utils/virtualEvent/eventlive.ts
+++ b/src/utils/virtualEvent/eventlive.ts
@@ -1,5 +1,6 @@
 import {
   _VirtualEventLinkParser,
+  _PATH_DELIMITER,
 
   _deriveUrlLinkText,
   _safelyParseUrl,
@@ -7,8 +8,7 @@ import {
 } from './_helpers';
 
 
-const RECOGNIZED_DOMAINS = [ 'evt.live' ];
-const PATH_DELIMITER = '/';
+const RECOGNIZED_DOMAINS = [ 'evt.live', 'eventlive.pro' ];
 
 
 export const parseLink: _VirtualEventLinkParser = (text: string) => {
@@ -30,12 +30,14 @@ export const parseLink: _VirtualEventLinkParser = (text: string) => {
   }
 
   // derive the Stream ID
-  //   '/<ACCOUNT>/<STREAM>'
-  const pathSegements = pathname.slice(1).split(PATH_DELIMITER);
-  if (pathSegements.length < 2) {
+  //   'evt.live/<ACCOUNT>/<STREAM>'
+  //   'eventlive.pro/event/<STREAM>'
+  //   ... which suggests that STREAM is unique across the platform (vs. just ACCOUNT)
+  const pathSegments = pathname.slice(1).split(_PATH_DELIMITER);
+  if (pathSegments.length < 2) {
     return null;
   }
-  const streamId = pathSegements.slice(0, 2).join(PATH_DELIMITER);
+  const streamId = pathSegments[1];
 
   return {
     urlLinkText,

--- a/src/utils/virtualEvent/googleMeet.spec.ts
+++ b/src/utils/virtualEvent/googleMeet.spec.ts
@@ -67,7 +67,7 @@ describe('service/virtualEvent/googleMeet', () => {
       it('parses a URL', () => {
         const TEXT = `
 To join the video meeting, click this link: https://meet.google.com/thr-four-ee3
-Otherwise, to join by phone, dial +1 252-986-3126 and enter this PIN: 333 333 333#
+Otherwise, to join by phone, dial +1 415-555-1212 and enter this PIN: 333 333 333#
 To view more phone numbers, click this link: https://tel.meet/thr-four-ee3?hs=5
         `.trim();
 

--- a/src/utils/virtualEvent/index.ts
+++ b/src/utils/virtualEvent/index.ts
@@ -2,79 +2,13 @@ import {
   VirtualEventProvider,
   VirtualEventLinkParseResult,
 } from './types';
-import {
-  _VirtualEventLinkParser,
-} from './_helpers';
-import { parseLink as parseZoomUrl } from './zoom';
-import { parseLink as parseYouTubeUrl } from './youtube';
-import { parseLink as parseGoogleMeetUrl } from './googleMeet';
-import { parseLink as parseEventLiveUrl } from './eventlive';
-import { parseLink as parseUnknownUrl } from './unknown';
-
+import { parseLink } from './aggregator';
 import * as schema from './schema';
-export const virtualEventGraphQL = schema;
 
-
-type _VirtualEventLinkProviderToolkit = {
-  provider: VirtualEventProvider,
-  parseLink: _VirtualEventLinkParser,
-};
-const PROVIDER_TOOLKITS: Array<_VirtualEventLinkProviderToolkit> = [
-  {
-    provider: VirtualEventProvider.zoom,
-    parseLink: parseZoomUrl,
-  },
-  {
-    provider: VirtualEventProvider.youtube,
-    parseLink: parseYouTubeUrl,
-  },
-  {
-    provider: VirtualEventProvider.googleMeet,
-    parseLink: parseGoogleMeetUrl,
-  },
-  {
-    provider: VirtualEventProvider.eventlive,
-    parseLink: parseEventLiveUrl,
-  },
-  // always last
-  {
-    provider: VirtualEventProvider.unknown,
-    parseLink: parseUnknownUrl,
-  },
-];
-
-
-// @public
 export {
   VirtualEventProvider,
   VirtualEventLinkParseResult,
+
+  parseLink as parseVirtualEventLink,
+  schema as virtualEventGraphQL,
 };
-
-export function parseVirtualEventLink(linkText: string): VirtualEventLinkParseResult | null {
-  if (! linkText) {
-    return null;
-  }
-
-  for (let { provider, parseLink } of PROVIDER_TOOLKITS) {
-    const parsed = parseLink(linkText);
-    if (parsed) {
-      return {
-        provider,
-        linkText,
-        isLinkValid: true,
-
-        ...parsed,
-      };
-    }
-  }
-
-  // whatever the Couple cut-and-pasted to us, we echo back;
-  //   no known Provider
-  //   we detected nothing useful
-  return {
-    provider: VirtualEventProvider.unknown,
-    linkText,
-    isLinkValid: false,
-    isPasswordDetected: false,
-  };
-}

--- a/src/utils/virtualEvent/schema.ts
+++ b/src/utils/virtualEvent/schema.ts
@@ -1,3 +1,4 @@
+import { IFieldResolver, IResolvers } from 'apollo-server';
 import gql from 'graphql-tag';
 import {
   DocumentNode,
@@ -6,6 +7,10 @@ import {
   buildASTSchema,
   typeFromAST,
 } from 'graphql';
+
+import { Context } from '../../server/apollo.context';
+import { VirtualEventLinkParseResult } from './types';
+import { parseLink } from './aggregator';
 
 
 export const markup = (options: {
@@ -53,6 +58,19 @@ export const markup = (options: {
 export const typeDefs: DocumentNode = gql( markup({
   queryTypeName: 'Query',
 }) );
+
+
+
+// as Resolvers
+const parseVirtualEventLink: IFieldResolver<null, Context, { text: string }> = (_, args, _context): VirtualEventLinkParseResult | null => {
+  return parseLink(args.text);
+}
+
+export const resolvers: IResolvers = {
+  Query: {
+    parseVirtualEventLink,
+  },
+};
 
 
 // as individual GraphQL Types

--- a/src/utils/virtualEvent/zoom.spec.ts
+++ b/src/utils/virtualEvent/zoom.spec.ts
@@ -18,31 +18,38 @@ describe('service/virtualEvent/zoom', () => {
       // it('constrains on domain')
       chaiExpects( parseLink('https://not-zoom.us/j/4155551212') ).to.equal(null);
 
-      // it('requires a Stream ID')
+      // it('requires a recognized path *and* a Stream ID')
+      chaiExpects( parseLink('https://zoom.us/UNRECOGNIZED/4155551212') ).to.equal(null);
+
+      chaiExpects( parseLink('https://zoom.us/j') ).to.equal(null);
       chaiExpects( parseLink('https://zoom.us/j/') ).to.equal(null);
+
       chaiExpects( parseLink('https://zoom.us/wc/') ).to.equal(null);
+      chaiExpects( parseLink('https://zoom.us/wc/4155551212') ).to.equal(null);
+      chaiExpects( parseLink('https://zoom.us/wc/join') ).to.equal(null);
+      chaiExpects( parseLink('https://zoom.us/wc/join/') ).to.equal(null);
     });
 
 
-    describe('from a URL', () => {
+    describe('from an App-launching URL', () => {
       // eg. "Copy Invite Link" text
-      const URL = 'https://zoom.us/wc/4155551212';
+      const URL = 'https://us04web.zoom.us/j/4155551212';
 
       it('parses a URL', () => {
         // it('parses a Web-Client-launching URL')
         chaiExpects( parseLink(URL) ).to.deep.equal({
           urlLinkText: URL,
           urlApp: 'https://zoom.us/j/4155551212',
-          urlBrowser: URL,
+          urlBrowser: 'https://zoom.us/wc/join/4155551212',
           streamId: '4155551212',
           isPasswordDetected: false,
           passwordUrlEmbed: undefined,
           passwordText: undefined,
         });
 
-        // it('can be generous')
-        chaiExpects( parseLink('https://zoom.us/wc/more/paths/4155551212') ).to.include({
-          urlBrowser: 'https://zoom.us/wc/4155551212',
+        // it('is generous about sub-paths')
+        chaiExpects( parseLink('https://zoom.us/j/more/paths/4155551212') ).to.include({
+          urlApp: 'https://zoom.us/j/4155551212',
           streamId: '4155551212',
         });
       });
@@ -51,7 +58,7 @@ describe('service/virtualEvent/zoom', () => {
         chaiExpects( parseLink(`Link Text: ${ URL }`) ).to.deep.equal({
           urlLinkText: URL,
           urlApp: 'https://zoom.us/j/4155551212',
-          urlBrowser: URL,
+          urlBrowser: 'https://zoom.us/wc/join/4155551212',
           streamId: '4155551212',
           isPasswordDetected: false,
           passwordUrlEmbed: undefined,
@@ -61,39 +68,24 @@ describe('service/virtualEvent/zoom', () => {
 
       it('parses a URL with a password', () => {
         // it('honors sub-domains')
-        // it('parses an App-launching URL')
         const TEXT = 'https://us04web.zoom.us/j/4155551212?pwd=P4s5w0r6';
 
         chaiExpects( parseLink(TEXT) ).to.deep.equal({
           urlLinkText: TEXT,
           // it('propagates the password')
           urlApp: 'https://zoom.us/j/4155551212?pwd=P4s5w0r6',
-          urlBrowser: 'https://zoom.us/wc/4155551212?pwd=P4s5w0r6',
+          urlBrowser: 'https://zoom.us/wc/join/4155551212?pwd=P4s5w0r6',
           streamId: '4155551212',
           isPasswordDetected: true,
           passwordUrlEmbed: 'P4s5w0r6',
           passwordText: undefined,
         });
 
-        // it('can be generous')
+        // it('is generous about sub-paths')
         chaiExpects( parseLink('https://zoom.us/j/more/paths/4155551212?pwd=P4s5w0r6') ).to.include({
           urlApp: 'https://zoom.us/j/4155551212?pwd=P4s5w0r6',
           streamId: '4155551212',
           passwordUrlEmbed: 'P4s5w0r6',
-        });
-      });
-
-      it('only reformats URLs which it can grok', () => {
-        const TEXT = 'https://zoom.us/weird/4155551212';
-
-        chaiExpects( parseLink(TEXT) ).to.deep.equal({
-          urlLinkText: TEXT,
-          urlApp: undefined,
-          urlBrowser: undefined,
-          streamId: '4155551212',
-          isPasswordDetected: false,
-          passwordUrlEmbed: undefined,
-          passwordText: undefined,
         });
       });
 
@@ -103,11 +95,36 @@ describe('service/virtualEvent/zoom', () => {
         chaiExpects( parseLink(TEXT) ).to.include({
           urlLinkText: 'https://us04web.zoom.us/j/4155551212',
           urlApp: 'https://zoom.us/j/4155551212',
-          urlBrowser: 'https://zoom.us/wc/4155551212',
+          urlBrowser: 'https://zoom.us/wc/join/4155551212',
           streamId: '4155551212',
           isPasswordDetected: true,
           passwordUrlEmbed: undefined,
           passwordText: 'PASSWORD',
+        });
+      });
+    });
+
+
+    describe('from a Web Client URL', () => {
+      // a URL variant that we're aware of
+      const URL = 'https://us02web.zoom.us/wc/join/4155551212';
+
+      it('parses a URL', () => {
+        // it('parses a Web-Client-launching URL')
+        chaiExpects( parseLink(URL) ).to.deep.equal({
+          urlLinkText: URL,
+          urlApp: 'https://zoom.us/j/4155551212',
+          urlBrowser: 'https://zoom.us/wc/join/4155551212',
+          streamId: '4155551212',
+          isPasswordDetected: false,
+          passwordUrlEmbed: undefined,
+          passwordText: undefined,
+        });
+
+        // it('is generous about sub-paths')
+        chaiExpects( parseLink('https://us02web.zoom.us/wc/join/more/paths/4155551212') ).to.include({
+          urlBrowser: 'https://zoom.us/wc/join/4155551212',
+          streamId: '4155551212',
         });
       });
     });
@@ -118,15 +135,15 @@ describe('service/virtualEvent/zoom', () => {
         // it('parses a Web-Client-launching URL')
         const TEXT = `
 Join Zoom Meeting
-https://zoom.us/wc/2675551212
+https://zoom.us/j/2675551212
 
 Meeting ID: 415 555 1212
         `.trim();
 
         chaiExpects( parseLink(TEXT) ).to.deep.equal({
-          urlLinkText: 'https://zoom.us/wc/2675551212',
+          urlLinkText: 'https://zoom.us/j/2675551212',
           urlApp: 'https://zoom.us/j/2675551212',
-          urlBrowser: 'https://zoom.us/wc/2675551212',
+          urlBrowser: 'https://zoom.us/wc/join/2675551212',
           streamId: '2675551212',
           isPasswordDetected: false,
           passwordUrlEmbed: undefined,
@@ -153,32 +170,8 @@ Passcode: PASSWORD
           urlLinkText: 'https://us04web.zoom.us/j/2675551212?pwd=P4s5w0r6',
           // it('propagates the password')
           urlApp: 'https://zoom.us/j/2675551212?pwd=P4s5w0r6',
-          urlBrowser: 'https://zoom.us/wc/2675551212?pwd=P4s5w0r6',
+          urlBrowser: 'https://zoom.us/wc/join/2675551212?pwd=P4s5w0r6',
           streamId: '2675551212',
-          isPasswordDetected: true,
-          passwordUrlEmbed: 'P4s5w0r6',
-          passwordText: 'PASSWORD',
-        });
-      });
-
-      it('only reformats URLs which it can grok', () => {
-        const TEXT = `
-Soup Nazi is inviting you to a scheduled Zoom meeting.
-
-Topic: Come Back... One Year
-
-Join Zoom Meeting
-https://zoom.us/no/soup/for/you/2125551212?pwd=P4s5w0r6
-
-Meeting ID: 212 555 1212
-Passcode: PASSWORD
-        `.trim();
-
-        chaiExpects( parseLink(TEXT) ).to.deep.equal({
-          urlLinkText: 'https://zoom.us/no/soup/for/you/2125551212?pwd=P4s5w0r6',
-          urlApp: undefined,
-          urlBrowser: undefined,
-          streamId: '2125551212',
           isPasswordDetected: true,
           passwordUrlEmbed: 'P4s5w0r6',
           passwordText: 'PASSWORD',
@@ -187,21 +180,22 @@ Passcode: PASSWORD
 
       it('detects a non-embedded password', () => {
         const TEXT = `
-Larry David is inviting you to a scheduled Zoom meeting.
+Soup Nazi is inviting you to a scheduled Zoom meeting.
 
-Topic: Dinner with Michael J. Fox
+Topic: Come Back... One Year
+Time: Nov 2, 1996 12:30 AM Eastern Time (US and Canada)
 
 Join Zoom Meeting
-https://us04web.zoom.us/j/2125551212
+https://us04web.zoom.us/wc/join/2125551212
 
 Meeting ID: 212 555 1212
 Passcode: PASSWORD
         `.trim();
 
         chaiExpects( parseLink(TEXT) ).to.include({
-          urlLinkText: 'https://us04web.zoom.us/j/2125551212',
+          urlLinkText: 'https://us04web.zoom.us/wc/join/2125551212',
           urlApp: 'https://zoom.us/j/2125551212',
-          urlBrowser: 'https://zoom.us/wc/2125551212',
+          urlBrowser: 'https://zoom.us/wc/join/2125551212',
           streamId: '2125551212',
           isPasswordDetected: true,
           passwordUrlEmbed: undefined,

--- a/test/apollo/virtualEvent.ts
+++ b/test/apollo/virtualEvent.ts
@@ -1,0 +1,129 @@
+import { gql } from 'apollo-server-core';
+
+import {
+  VirtualEventProvider,
+  virtualEventGraphQL,
+} from '../../src/utils/virtualEvent';
+const { typeDefs, resolvers } = virtualEventGraphQL;
+
+import { testSetupApollo } from '../helpers/apollo';
+
+
+describe('the GraphQL Color TypeDefs', () => {
+  let client: { query: Function };
+
+
+  beforeEach(async () => {
+    const setup = await testSetupApollo({
+      typeDefs: [
+        gql`
+          type Query {
+            _whichGetsExtended: Boolean
+          }
+        `,
+        typeDefs,
+      ],
+      resolvers,
+    });
+    client = setup.client;
+  });
+
+
+  describe('parseVirtualEventLink', () => {
+    it('parses a VirtualEvent link', async () => {
+      const TEXT = 'https://us04web.zoom.us/j/4155551212?pwd=P4s5w0r6 (Password: PASSWORD!)';
+
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            parseVirtualEventLink(text: "${ TEXT }") {
+              provider
+              linkText
+              isLinkValid
+              urlLinkText
+              urlApp
+              urlBrowser
+              streamId
+              isPasswordDetected
+              passwordUrlEmbed
+              passwordText
+            }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toEqual({
+        parseVirtualEventLink: {
+          provider: VirtualEventProvider.zoom,
+          linkText: TEXT,
+          isLinkValid: true,
+          urlLinkText: 'https://us04web.zoom.us/j/4155551212?pwd=P4s5w0r6',
+          urlApp: 'https://zoom.us/j/4155551212?pwd=P4s5w0r6',
+          urlBrowser: 'https://zoom.us/wc/join/4155551212?pwd=P4s5w0r6',
+          streamId: '4155551212',
+          isPasswordDetected: true,
+          passwordUrlEmbed: 'P4s5w0r6',
+          passwordText: 'PASSWORD!',
+        },
+      });
+    });
+
+    it('parses an un-parseable VirtualEvent link', async () => {
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            parseVirtualEventLink(text: "UNPARSEABLE") {
+              provider
+              linkText
+              isLinkValid
+              urlLinkText
+              urlApp
+              urlBrowser
+              streamId
+              isPasswordDetected
+              passwordUrlEmbed
+              passwordText
+            }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toEqual({
+        parseVirtualEventLink: {
+          provider: VirtualEventProvider.unknown,
+          linkText: 'UNPARSEABLE',
+          isLinkValid: false,
+          urlLinkText: null,
+          urlApp: null,
+          urlBrowser: null,
+          streamId: null,
+          isPasswordDetected: false,
+          passwordUrlEmbed: null,
+          passwordText: null,
+        },
+      });
+    });
+
+    it('cannot parse the lack of a link', async () => {
+      const { query } = client;
+      const res = await query({
+        query: gql`
+          query {
+            parseVirtualEventLink(text: "") {
+              provider
+            }
+          }
+        `
+      });
+
+      const { data } = res;
+      expect(data).toEqual({
+        parseVirtualEventLink: null,
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Zoom Web Client path is '/wc/join/:streamId'
- Eventlive parser support for 'eventlive.pro/event/:streamId'
- Eventlive Stream ID is now assumed to be Account-agnostic
- stricter parsing of Zoom URLs; known patterns only (App + Web Client)

And while I was at it,

- split out aggregator logic from 'index'; now index' is just `export`s
- provided standard GraphQL Resolvers (to match TypeDefs)
- GraphQL end-to-end testing