### PR TITLE
Revert "VEN-476 iOS did not migrate to `{ isPasswordDetected }`; we must re-introduce `{ passwordDetected }`"

### DIFF
--- a/src/utils/virtualEvent/aggregator.spec.ts
+++ b/src/utils/virtualEvent/aggregator.spec.ts
@@ -19,8 +19,6 @@ describe('service/virtualEvent/aggregator', () => {
         linkText: 'http-ish String',
         isLinkValid: false,
         isPasswordDetected: false,
-        // FIXME:  @deprecated
-        passwordDetected: false,
       });
 
       // it('even matches minimal whitespace')
@@ -29,8 +27,6 @@ describe('service/virtualEvent/aggregator', () => {
         linkText: ' ',
         isLinkValid: false,
         isPasswordDetected: false,
-        // FIXME:  @deprecated
-        passwordDetected: false,
       });
     });
 
@@ -48,8 +44,6 @@ describe('service/virtualEvent/aggregator', () => {
         isPasswordDetected: true,
         passwordUrlEmbed: 'P4s5w0r6',
         passwordText: undefined,
-        // FIXME:  @deprecated
-        passwordDetected: true,
       });
     });
 
@@ -63,8 +57,6 @@ describe('service/virtualEvent/aggregator', () => {
         urlLinkText: TEXT,
         streamId: 'dQw4w9WgXcQ',
         isPasswordDetected: false,
-        // FIXME:  @deprecated
-        passwordDetected: false,
       });
     });
 
@@ -78,8 +70,6 @@ describe('service/virtualEvent/aggregator', () => {
         urlLinkText: TEXT,
         streamId: 'thr-four-ee3',
         isPasswordDetected: false,
-        // FIXME:  @deprecated
-        passwordDetected: false,
       });
     });
 
@@ -93,8 +83,6 @@ describe('service/virtualEvent/aggregator', () => {
         urlLinkText: TEXT,
         streamId: 'STREAM',
         isPasswordDetected: false,
-        // FIXME:  @deprecated
-        passwordDetected: false,
       });
     });
 
@@ -107,8 +95,6 @@ describe('service/virtualEvent/aggregator', () => {
         urlLinkText: TEXT,
         isLinkValid: true,
         isPasswordDetected: false,
-        // FIXME:  @deprecated
-        passwordDetected: false,
       });
     });
   });

--- a/src/utils/virtualEvent/aggregator.ts
+++ b/src/utils/virtualEvent/aggregator.ts
@@ -56,9 +56,6 @@ export function parseLink(linkText: string): VirtualEventLinkParseResult | null 
         isLinkValid: true,
 
         ...parsed,
-
-        // FIXME:  @deprecated
-        passwordDetected: parsed.isPasswordDetected,
       };
     }
   }
@@ -71,7 +68,5 @@ export function parseLink(linkText: string): VirtualEventLinkParseResult | null 
     linkText,
     isLinkValid: false,
     isPasswordDetected: false,
-    // FIXME:  @deprecated
-    passwordDetected: false,
   };
 }

--- a/src/utils/virtualEvent/schema.ts
+++ b/src/utils/virtualEvent/schema.ts
@@ -46,9 +46,6 @@ export const markup = (options: {
     passwordUrlEmbed: String
     "The clear-text password called out in the link text, if detected"
     passwordText: String
-
-    # FIXME:  @deprecated
-    passwordDetected: Boolean!  @deprecated(reason: "replaced by \`isPasswordDetected\`")
   }
 
   ${ options.noExtend ? '' : 'extend' } type ${ options.queryTypeName } {

--- a/src/utils/virtualEvent/types.ts
+++ b/src/utils/virtualEvent/types.ts
@@ -16,6 +16,4 @@ export type VirtualEventLinkParseResult = _VirtualEventLinkParseFragment & {
   provider: VirtualEventProvider;
   linkText: string;
   isLinkValid: boolean;
-  // FIXME:  @deprecated
-  passwordDetected: boolean;
 }

--- a/test/apollo/virtualEvent.ts
+++ b/test/apollo/virtualEvent.ts
@@ -48,9 +48,6 @@ describe('the GraphQL Color TypeDefs', () => {
               isPasswordDetected
               passwordUrlEmbed
               passwordText
-
-              # FIXME:  @deprecated
-              passwordDetected
             }
           }
         `
@@ -69,7 +66,6 @@ describe('the GraphQL Color TypeDefs', () => {
           isPasswordDetected: true,
           passwordUrlEmbed: 'P4s5w0r6',
           passwordText: 'PASSWORD!',
-          passwordDetected: true,
         },
       });
     });
@@ -90,9 +86,6 @@ describe('the GraphQL Color TypeDefs', () => {
               isPasswordDetected
               passwordUrlEmbed
               passwordText
-
-              # FIXME:  @deprecated
-              passwordDetected
             }
           }
         `
@@ -111,7 +104,6 @@ describe('the GraphQL Color TypeDefs', () => {
           isPasswordDetected: false,
           passwordUrlEmbed: null,
           passwordText: null,
-          passwordDetected: false,
         },
       });
     });


### PR DESCRIPTION
This reverts commit 1677447d9bcebb0c8f7c71f7fd45166624bfc286.

## explanation

the iOS Team has not submitted a version of the App that does a bad query to Apple for review.  the reason that we saw a failure when doing `ENVIRONMENT=production yarn schema:diff` is that they'd used Production for testing pre-release builds