### PR TITLE
CORE-823 migrate re-usable features from `event_service`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,10 @@ module.exports = {
   coverageReporters: ['json', 'lcov', 'text'],
   coverageThreshold: {
     global: {
-      statements: 73.2,
-      branches: 79.2,
-      functions: 51.3,
-      lines: 73.9,
+      statements: 74.0,
+      branches: 78.8,
+      functions: 52.1,
+      lines: 74.7,
     },
   },
   globals: {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "forwarded": "~0.1.2",
     "graphql": "^14.7.0",
     "graphql-tag": "^2.11.0",
+    "graphql-type-json": "^0.3.2",
     "immer": "^3.1.3",
     "jsonwebtoken": "8.4.0",
     "lodash": "4.17.13",

--- a/src/graphql/core.types.ts
+++ b/src/graphql/core.types.ts
@@ -1,7 +1,10 @@
 import { gql, IResolvers } from 'apollo-server';
 import moment, { Moment } from 'moment-timezone';
 import chroma, { Color } from 'chroma-js';
+import { GraphQLJSONObject } from 'graphql-type-json';
+
 import { Context } from 'src/server/apollo.context';
+
 
 const UTC_LONG = 'Etc/UTC';
 const UTC_SHORT = 'UTC';
@@ -13,6 +16,8 @@ const REGEX_FORMAT = /^\d{4}-\d{2}-\d{2}$/
 const FORMAT_TIMESTAMP = 'YYYY-MM-DD[T]HH:mm:ss.SSSZ';
 
 export const coreTypeDefs = gql`
+
+  scalar JSONObject
 
   type Color {
     hex: String!
@@ -229,9 +234,9 @@ export function parseCoreTypeInputDateAndTimezone(date: string | null | undefine
 }
 
 
-
-
 export const coreResolvers: IResolvers = {
+  JSONObject: GraphQLJSONObject,
+
   Date: {
     timestamp: (date: _CoreTypeDateTuple): string => {
       const convertedDate = _convertDateTupleToMoment(date);
@@ -276,6 +281,7 @@ export const coreResolvers: IResolvers = {
       }
     },
   },
+
   Color: {
     hex: (color: string | number): string => {
       return _convertColorToChroma(color).hex();

--- a/src/graphql/federated.types.spec.ts
+++ b/src/graphql/federated.types.spec.ts
@@ -1,0 +1,81 @@
+import {
+  federatedUserById,
+  federatedEventById,
+  federatedPhotoById,
+  federatedVideoById,
+} from './federated.types';
+
+const MODEL_ID = 'MODEL_ID';
+
+
+describe('graphql/federated.types', () => {
+  describe('federatedUserById', () => {
+    it('returns a Federated Photo reference', () => {
+      expect(federatedUserById(MODEL_ID)).toEqual({
+        __typename: 'User',
+        id: MODEL_ID,
+      });
+    });
+
+    it('requires an id', () => {
+      expect(federatedUserById(null)).toBeNull();
+      expect(federatedUserById(undefined)).toBeNull();
+    });
+  });
+
+  describe('federatedEventById', () => {
+    it('returns a Federated Photo reference', () => {
+      expect(federatedEventById(MODEL_ID)).toEqual({
+        __typename: 'Event',
+        id: MODEL_ID,
+      });
+    });
+
+    it('requires an id', () => {
+      expect(federatedEventById(null)).toBeNull();
+      expect(federatedEventById(undefined)).toBeNull();
+    });
+  });
+
+  describe('federatedPhotoById', () => {
+    it('returns a Federated Photo reference', () => {
+      expect(federatedPhotoById(MODEL_ID)).toEqual({
+        __typename: 'Photo',
+        id: MODEL_ID,
+      });
+    });
+
+    it('requires an id', () => {
+      expect(federatedPhotoById(null)).toBeNull();
+      expect(federatedPhotoById(undefined)).toBeNull();
+    });
+  });
+
+  describe('federatedUserById', () => {
+    it('returns a Federated Photo reference', () => {
+      expect(federatedUserById(MODEL_ID)).toEqual({
+        __typename: 'User',
+        id: MODEL_ID,
+      });
+    });
+
+    it('requires an id', () => {
+      expect(federatedUserById(null)).toBeNull();
+      expect(federatedUserById(undefined)).toBeNull();
+    });
+  });
+
+  describe('federatedVideoById', () => {
+    it('returns a Federated Photo reference', () => {
+      expect(federatedVideoById(MODEL_ID)).toEqual({
+        __typename: 'Video',
+        id: MODEL_ID,
+      });
+    });
+
+    it('requires an id', () => {
+      expect(federatedVideoById(null)).toBeNull();
+      expect(federatedVideoById(undefined)).toBeNull();
+    });
+  });
+});

--- a/src/graphql/federated.types.ts
+++ b/src/graphql/federated.types.ts
@@ -1,0 +1,21 @@
+export interface FederatedTypeReference {
+  __typename: string;
+  id: string;
+}
+type FederatedMaybeId = string | null | undefined;
+type FederatedTypeResolver = (id: FederatedMaybeId) => FederatedTypeReference | null;
+
+function _federatedTypeById(__typename: string): FederatedTypeResolver {
+  return function _federatedType(id: FederatedMaybeId) {
+    if (! id) {
+      return null;
+    }
+    return { __typename, id };
+  }
+}
+
+
+export const federatedUserById = _federatedTypeById('User'); // => `identity_service.User`
+export const federatedEventById = _federatedTypeById('Event'); // => `event_service.Event`
+export const federatedPhotoById = _federatedTypeById('Photo'); // => `photo_service.Photo`
+export const federatedVideoById = _federatedTypeById('Video'); // => `photo_service.Video`

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ import {
   NotFoundError
 } from './server/errors';
 
-import { ControllerTemplate } from './templates/controller.template';
+import { ControllerTemplate, ControllerTemplateWithContext } from './templates/controller.template';
 import { ModelViewTemplate, ViewTemplate } from './templates/view.template';
 import { ModelTemplate, ModelTemplateClass } from './templates/model.template';
 import {
@@ -51,6 +51,13 @@ import {
   parseCoreTypeInputDateAndTimezone,
   parseCoreTypeInputTimezone,
 } from './graphql/core.types'
+import {
+  FederatedTypeReference,
+  federatedUserById,
+  federatedEventById,
+  federatedPhotoById,
+  federatedVideoById,
+} from './graphql/federated.types'
 import { createGraphQLEnumValues } from './utils/graphql.enum';
 import { EdgeWrapper, edgeWrapperType } from './utils/edge.wrapper';
 import {
@@ -129,6 +136,7 @@ export {
   SESSION_REQUEST_PROPERTY,
 
   ControllerTemplate,
+  ControllerTemplateWithContext,
   ModelTemplate,
   ModelTemplateClass,
   ModelViewTemplate,
@@ -150,6 +158,11 @@ export {
   formatCoreTypeDateTimestamp,
   parseCoreTypeInputDateAndTimezone,
   parseCoreTypeInputTimezone,
+  FederatedTypeReference,
+  federatedUserById,
+  federatedEventById,
+  federatedPhotoById,
+  federatedVideoById,
   createGraphQLEnumValues,
 
   EdgeWrapper,

--- a/src/templates/controller.template.ts
+++ b/src/templates/controller.template.ts
@@ -1,6 +1,9 @@
-import DataLoader from 'dataloader';
-import { keyBy } from 'lodash';
+import DataLoader, { Options } from 'dataloader';
+import { compact, groupBy, keyBy } from 'lodash';
 import { produce } from 'immer';
+
+import { ModelTemplate } from './model.template';
+import { IContext } from '../server/apollo.context';
 
 
 // <T> = the ModelTemplate / `typeorm` @Entity type being controlled
@@ -9,17 +12,19 @@ import { produce } from 'immer';
 //   @see the spec file for a practical example
 export class ControllerTemplate<T, LoaderKeys extends string> {
 
-  // a pool of DataLoaders, keyed by <LoaderKeys>
-  //   eg. `const user = await this.loaders['byUsername'].load('uniqueUsername');`
+  // DataLoaders, keyed by <LoaderKeys>
+  //   which return a single Model per query
+  //   eg. `const userByUsername: User | null = await this.loaders['byUsername'].load('uniqueUsername');`
+  //   eg. `const usersByUsername: User[] = await this.loaders['byUsername'].loadMany([ 'user-A', 'user-B' ]);`
+  //   @see the spec file for a practical example
   public loaders: Record<LoaderKeys, DataLoader<string, T>> = {} as Record<LoaderKeys, DataLoader<string, T>>;
 
-  // a helper for integrating TypeORM and the DataLoader pool
+  // helpers for integrating TypeORM and single-Model DataLoaders
   //   eg. `this.loaders.byId = this.wrapQueryInDataLoader(async (ids: string[]) => { ... });`
   //   @see the spec file for a practical example
   public wrapQueryInDataLoader(query: (keys: Array<string>) => Promise<Array<T>>): DataLoader<string, T> {
     return new DataLoader(query);
   }
-
 
   // "orderResultsBy" methods are used to reorient your TypeORM Models returned by `wrapQueryInDataLoader`
   //   so that they have a one-to-one ordering with the `ids` passed to your wrapper
@@ -73,6 +78,46 @@ export class ControllerTemplate<T, LoaderKeys extends string> {
   }
 
 
+  // DataLoaders, (also) keyed by <LoaderKeys>
+  //   which return a multiple Models per query
+  //   eg. `const usersForEvent: Array<User> | null = await this.loaders['forEvent'].load('eventId');`
+  //   eg. `const usersForEvents: Array<User>[] = await this.loaders['forEvent'].loadMany([ 'event-A', 'event-B' ]);`
+  //   @see the spec file for a practical example
+  public loadersMulti: Record<LoaderKeys, DataLoader<string, Array<T>>> = {} as Record<LoaderKeys, DataLoader<string, Array<T>>>;
+
+  // helpers for integrating TypeORM and multiple-Model DataLoaders
+  public wrapQueryInDataLoaderMulti = (
+    query: (keys: Array<string>) => Promise<Array<Array<T>>>, // an Array of Model Arrays
+    options?: Options<string, Array<T>>
+  ): DataLoader<string, Array<T>> => {
+    return new DataLoader(query, options);
+  }
+
+  /**
+   * @param ids {String[]} the IDs used for the DataLoader fetch
+   * @param results {T[]} the Models resolved by the DataLoader fetch
+   * @param [idDeriver] {Function} a Function returning an ID which corresponds to a value from `ids`
+   * @returns {T[T[]]} an Array of Model Arrays,
+   *   grouped / collated per the `ids` provided
+   *   and ordered in one-to-one correspondence with `ids`.
+   *   when no Models match a given ID, its corresponding Array is empty (vs. undefined)
+   */
+  public groupAndOrderMultiResultsByIds = (
+    ids: Array<string>,
+    results: Array<T>,
+    idDeriver: (model: T) => string // | null | undefined
+  ): Array<Array<T>> => {
+    // TODO:  fail if `resultsGrouped` contains any key *outside of* `ids`?
+    const resultsGrouped = groupBy(results, idDeriver);
+
+    // any ID with no results gets an empty Array
+    return ids.map((id) => {
+      const grouped = resultsGrouped[id];
+      return (grouped ? compact(grouped) : []);
+    });
+  }
+
+
   public updateIndexOrder<T extends { index: number }>(items: Array<T>, from: number, to: number): Array<T> {
     items = items.sort((a, b) => a.index - b.index);
     if (from < 0 || from + 1 > items.length || to < 0 || to + 1 > items.length) {
@@ -91,4 +136,19 @@ export class ControllerTemplate<T, LoaderKeys extends string> {
     }
   }
 
+}
+
+
+// a Controller that is aware of its own Context
+//   <C> = the Context being controlled
+export class ControllerTemplateWithContext<T extends ModelTemplate, C extends IContext, LoaderKeys extends string>
+  extends ControllerTemplate<T, LoaderKeys>
+{
+  public readonly context: C;
+
+  constructor(context: C) {
+    super();
+
+    this.context = context;
+  }
 }

--- a/src/templates/fake.model.ts
+++ b/src/templates/fake.model.ts
@@ -4,14 +4,14 @@ import { ModelTemplate } from './model.template';
 @Entity()
 export class FakeModel extends ModelTemplate {
   @Column('text')
+  public code: string;
+
+  @Column('text')
   public fakeData: string;
 }
 
 @Entity()
-export class FakeModelWithIndex extends ModelTemplate {
-  @Column('text')
-  public fakeData: string;
-
+export class FakeModelWithIndex extends FakeModel {
   @Column('int')
   public index: number;
 }

--- a/src/templates/view.template.spec.ts
+++ b/src/templates/view.template.spec.ts
@@ -10,25 +10,32 @@ describe('ModelViewTemplate<T>', () => {
 
   describe('getter methods', () => {
     it('should return data from the Model used in the contructor', () => {
+      const DATE = new Date();
+
       const fakeData1 = new FakeModel();
       fakeData1.key = 1;
       fakeData1.id = '1';
+      fakeData1.createAt = DATE;
+      fakeData1.updateAt = DATE;
       const fakeData2 = new FakeModel();
       fakeData1.key = 2;
       fakeData2.id = '2';
       const viewTemplate1 = new ModelViewTemplate(contextMock.object, fakeData1);
       const viewTemplate2 = new ModelViewTemplate(contextMock.object, fakeData2);
+
       expect(viewTemplate1.context).toBe(contextMock.object);
       expect(viewTemplate1.data).toBe(fakeData1);
       expect(viewTemplate1.key).toEqual(fakeData1.key);
       expect(viewTemplate1.id).toEqual(fakeData1.id);
-      expect(viewTemplate1.createdAt).toEqual(fakeData1.createAt);
-      expect(viewTemplate1.updatedAt).toEqual(fakeData1.updateAt);
+      expect(viewTemplate1.updatedAt).toBe(fakeData1.createAt.toISOString());
+      expect(viewTemplate1.createdAt).toBe(fakeData1.updateAt.toISOString());
+
+      expect(viewTemplate2.context).toBe(contextMock.object);
       expect(viewTemplate2.data).toBe(fakeData2);
       expect(viewTemplate2.key).toEqual(fakeData2.key);
       expect(viewTemplate2.id).toEqual(fakeData2.id);
-      expect(viewTemplate2.createdAt).toEqual(fakeData2.createAt);
-      expect(viewTemplate2.updatedAt).toEqual(fakeData2.updateAt);
+      expect(viewTemplate2.createdAt).toBeNull();
+      expect(viewTemplate2.updatedAt).toBeNull();
     });
   });
 

--- a/src/templates/view.template.ts
+++ b/src/templates/view.template.ts
@@ -1,5 +1,10 @@
 import { IContext } from '../server/apollo.context';
 import { ModelTemplate } from './model.template';
+import {
+  CoreTypeDate,
+  resolveCoreTypeDate,
+} from '../graphql/core.types';
+
 
 export class ViewTemplate<T, C extends IContext> {
   public data: T;
@@ -16,7 +21,8 @@ export class ViewTemplate<T, C extends IContext> {
 }
 
 export class ModelViewTemplate<T extends ModelTemplate, C extends IContext> extends ViewTemplate<T, C> {
-
+  // convenience method; do *NOT* expose via GraphQL
+  //   we should only expose our public-facing UUIDs
   get key() {
     return this.data.key;
   }
@@ -25,11 +31,13 @@ export class ModelViewTemplate<T extends ModelTemplate, C extends IContext> exte
     return this.data.id;
   }
 
-  get createdAt() {
-    return this.data.createAt;
+  get createdAt(): CoreTypeDate | null {
+    // timezone-agonistic
+    return resolveCoreTypeDate(this.data.createAt, undefined);
   }
 
-  get updatedAt() {
-    return this.data.updateAt;
+  get updatedAt(): CoreTypeDate | null {
+    // timezone-agonistic
+    return resolveCoreTypeDate(this.data.updateAt, undefined);
   }
 }

--- a/src/utils/edge.wrapper.ts
+++ b/src/utils/edge.wrapper.ts
@@ -6,7 +6,7 @@ import {
   GraphQLBoolean,
   GraphQLObjectTypeConfig
 } from 'graphql';
-import { Context, IContext } from '../server/apollo.context';
+import { IContext } from '../server/apollo.context';
 
 import { ModelViewTemplate } from '../templates/view.template';
 

--- a/test/apollo/core.types.color.ts
+++ b/test/apollo/core.types.color.ts
@@ -4,8 +4,10 @@ import { coreTypeDefs, coreResolvers } from '../../src/graphql/core.types';
 import { testSetupApollo } from '../helpers/apollo';
 
 
-// PANTONE 17-1937 TCX Hot Pink @ 100%
-const COLOR_HEX = '#E55982FF';
+// PANTONE 130 U @ 100%
+//   https://www.reddit.com/r/sanfrancisco/comments/ipmrpu/til_the_apocalypse_is_pantone_130_u_oak_gough_noon/
+//   https://www.pantone.com/color-finder/130-U
+const COLOR_HEX = '#F79B2FFF';
 
 
 describe('the GraphQL Color TypeDefs', () => {
@@ -48,8 +50,8 @@ describe('the GraphQL Color TypeDefs', () => {
     const { data } = res;
     expect(data).toMatchObject({
       color: {
-        hex: '#e55982',
-        rgba: [ 229, 89, 130, 1 ],
+        hex: '#f79b2f',
+        rgba: [ 247, 155, 47, 1 ],
         isLight: false,
       },
     });

--- a/test/apollo/core.types.jsonObject.ts
+++ b/test/apollo/core.types.jsonObject.ts
@@ -1,0 +1,181 @@
+import { gql } from 'apollo-server-core';
+import { isEqual } from 'lodash';
+
+import { coreTypeDefs } from '../../src/graphql/core.types';
+import { testSetupApollo } from '../helpers/apollo';
+
+
+const OBJECT = { json: true };
+const STRING = 'STRING';
+const QUERY_TYPEDEFS = gql`
+  type Query {
+    jsonQuery: JSONObject  # because we test null
+  }
+`;
+
+
+describe('the GraphQL JSONObject TypeDefs', () => {
+  describe('for a Query', () => {
+    const QUERY = gql`
+      query {
+        jsonQuery
+      }
+    `;
+    let client: { query: Function };
+    let resolved: any;
+
+    beforeEach(async () => {
+      const setup = await testSetupApollo({
+        typeDefs: [
+          coreTypeDefs,
+          QUERY_TYPEDEFS,
+        ],
+        resolvers: {
+          Query: {
+            jsonQuery: () => resolved,
+          },
+        },
+      });
+      client = setup.client;
+    });
+
+    it('resolves an Object payload', async () => {
+      const { query } = client;
+      resolved = OBJECT;
+
+      const res = await query({
+        query: QUERY,
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        jsonQuery: resolved,
+      });
+    });
+
+    it('resolves a non-Object payload, regardless of its scalar Type name', async () => {
+      const { query } = client;
+      resolved = STRING;
+
+      const res = await query({
+        query: QUERY,
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        jsonQuery: resolved,
+      });
+    });
+
+    it('resolves a null payload', async () => {
+      const { query } = client;
+      resolved = null;
+
+      const res = await query({
+        query: QUERY,
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        jsonQuery: resolved,
+      });
+    });
+
+    it('resolves an undefined payload as null', async () => {
+      // which is probably standard GraphQL behavior
+      const { query } = client;
+      resolved = undefined;
+
+      const res = await query({
+        query: QUERY,
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        jsonQuery: null,
+      });
+    });
+  });
+
+
+  describe('for a Mutation', () => {
+    let client: { mutate: Function };
+    let expected: any;
+
+    beforeEach(async () => {
+      const setup = await testSetupApollo({
+        typeDefs: [
+          coreTypeDefs,
+          QUERY_TYPEDEFS,
+          gql`
+            type Mutation {
+              jsonMutation(actual: JSONObject): Boolean
+            }
+          `,
+        ],
+        resolvers: {
+          Mutation: {
+            jsonMutation: (_self: any, args: { actual: any }, _context: any) => {
+              return isEqual(args.actual, expected);
+            },
+          },
+        },
+      });
+      client = setup.client;
+    });
+
+    it('takes an Object payload', async () => {
+      const { mutate } = client;
+      expected = OBJECT;
+
+      const res = await mutate({
+        query: `
+          mutation {
+            jsonMutation(actual: { json: true })  # can't just JSON.stringify :(
+          }
+        `,
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        jsonMutation: true,
+      });
+    });
+
+    it('takes a non-Object payload, regardless of its scalar Type name', async () => {
+      const { mutate } = client;
+      expected = STRING;
+
+      const res = await mutate({
+        query: `
+          mutation {
+            jsonMutation(actual: "${ STRING }")
+          }
+        `,
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        jsonMutation: true,
+      });
+    });
+
+    it('takes a null payload', async () => {
+      const { mutate } = client;
+      expected = null;
+
+      const res = await mutate({
+        query: `
+          mutation {
+            jsonMutation(actual: null)
+          }
+        `,
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        jsonMutation: true,
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,6 +3401,11 @@ graphql-tools@^4.0.0:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
+graphql-type-json@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
+  integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
+
 graphql-upload@^8.0.2:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-8.0.4.tgz#ed7cbde883b5cca493de77e39f95cddf40dfd514"


### PR DESCRIPTION
- ModelViewTemplate resolves CoreTypeDate for `{ createdAt, updatedAt }`
- ControllerTemplate gets `loadersMulti` + supporting wrappers & utilities
- utilities to output Federated references to common `@external` Service Type
- JSONObject as a core type, per `graphql-type-json`
- couldn't stop myself from updating the Pantone example to 130-U #2020hindsight
- upped the Test Coverage thresholds a wee bit