### PR TITLE
CHORE calls to logContextRequest are not getting the Session ID

### DIFF
--- a/src/middleware/defaults.spec.ts
+++ b/src/middleware/defaults.spec.ts
@@ -31,6 +31,7 @@ describe('middleware/defaults', () => {
 
       const NAMES = [
         'corsMiddleware',
+        'sessionMiddleware',
         'logger',
       ];
       expect(Array.from(preludesMap.keys())).toEqual(NAMES);
@@ -56,7 +57,6 @@ describe('middleware/defaults', () => {
       const { apolloMap, apollo } = getDefaultMiddleware();
 
       const NAMES = [
-        'sessionMiddleware',
         'bodyParserGraphql',
       ];
       expect(Array.from(apolloMap.keys())).toEqual(NAMES);

--- a/src/middleware/defaults.ts
+++ b/src/middleware/defaults.ts
@@ -121,6 +121,7 @@ export function getDefaultMiddleware(): DefaultMiddlewareResult {
       // required for Cookie support
       credentials: true,
     }),
+    sessionMiddleware(),
     MORGAN_LOGGER,
   ].map(_tupleByMiddlewareName));
 
@@ -131,7 +132,6 @@ export function getDefaultMiddleware(): DefaultMiddlewareResult {
   ].map(_tupleByMiddlewareName));
 
   const apolloMap = new Map<string, RequestHandler>([
-    sessionMiddleware(),
     bodyParserGraphql({ limit: '100Kb' }),
   ].map(_tupleByMiddlewareName));
 

--- a/src/utils/miscellaneous.spec.ts
+++ b/src/utils/miscellaneous.spec.ts
@@ -25,7 +25,8 @@ describe('utils/miscellaneous', () => {
 
   describe('executeOperationsInParallel', () => {
     // a bunch of arbitrary items
-    const ITEMS = (new Array( 20 )).fill(0).map((_, index) => index);
+    const ITEM_COUNT = 20;
+    const ITEMS = (new Array<number>( ITEM_COUNT )).fill(0).map((_, index) => index);
 
     it('executes Model in parallel', async () => {
       const visitedItems: number[] = [];
@@ -46,9 +47,13 @@ describe('utils/miscellaneous', () => {
       const INTERVAL = 100; // ms; enough to be "precise"
       const nowAtStart = Date.now();
       const stamps: number[] = [];
+      const iteratorIndexes: number[] = [];
+      let iteratorItems: Array<number> = [];
 
-      await executeOperationsInParallel(ITEMS, async (model) => {
+      await executeOperationsInParallel(ITEMS, async (item, index, items) => {
         stamps.push(Date.now() - nowAtStart);
+        iteratorIndexes.push(index);
+        iteratorItems = items;
 
         // a time lag, to differentiate the batches;
         //   batch N Promises will all resolve "at the same time"
@@ -65,6 +70,13 @@ describe('utils/miscellaneous', () => {
         2, 2, 2, 2, 2, 2,
         3, 3,
       ]);
+
+      // it('provides iterator arguments')
+      expect(iteratorIndexes).toEqual([
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ]);
+      expect(iteratorItems).toBe(ITEMS);
     });
   });
 });

--- a/test/helpers/apollo.ts
+++ b/test/helpers/apollo.ts
@@ -23,6 +23,9 @@ export async function testSetupApollo(options?: ITestSetupApollo) {
   const schema: GraphQLSchema = await makeExecutableSchema({
     typeDefs: getProperty(options, 'typeDefs') || [],
     resolvers: getProperty(options, 'resolvers') || [],
+    resolverValidationOptions: {
+      requireResolversForResolveType: false,
+    },
   });
   const args: IApolloServerArgs = {
     schema,


### PR DESCRIPTION
which is important to log tracing / correlation

- Session ID handling should be default middleware, vs. just Apollo

also

- `executeOperationsInParallel` passes standard Iterator arguments
- eliminated silly Apollo warning in Test Suite setup