### PR TITLE
CORE-1311 support for additional `express`-related features

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from './server/apollo.config'
 import { IApolloServerArgs, createApolloServer } from './server/apollo.server'
 import { IServer, Server } from './server/server'
-import { initApp } from './server/server.init';
+import { initApp, shutdownCurrentApp } from './server/server.init';
 import { bodyParserGraphql } from './middleware/body.parser';
 import { getDefaultMiddleware } from './middleware/defaults';
 import {
@@ -156,6 +156,7 @@ export {
   IServer,
   Server,
   initApp,
+  shutdownCurrentApp,
 
   bodyParserGraphql,
   getDefaultMiddleware,

--- a/src/middleware/defaults.ts
+++ b/src/middleware/defaults.ts
@@ -1,8 +1,7 @@
 import { get as getProperty, isString, last } from 'lodash';
-import { Request, Response, RequestHandler } from 'express';
+import { Request, Response } from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
-import { TokenIndexer } from 'morgan';
 import bodyParser from 'body-parser';
 import forwarded from 'forwarded';
 import {
@@ -10,20 +9,21 @@ import {
   TelemetryLevel
 } from '@withjoy/telemetry';
 
+import { RequestHandlerVariant } from './types';
 import { bodyParserGraphql } from './body.parser';
 import { sessionMiddleware, SESSION_REQUEST_PROPERTY } from './session';
 
 interface DefaultMiddlewareResult {
-  preludesMap: Map<string, RequestHandler>;
-  preludes: RequestHandler[];
-  bodyParsersMap: Map<string, RequestHandler>;
-  bodyParsers: RequestHandler[];
-  apolloMap: Map<string, RequestHandler>;
-  apollo: RequestHandler[];
+  preludesMap: Map<string, RequestHandlerVariant>;
+  preludes: RequestHandlerVariant[];
+  bodyParsersMap: Map<string, RequestHandlerVariant>;
+  bodyParsers: RequestHandlerVariant[];
+  apolloMap: Map<string, RequestHandlerVariant>;
+  apollo: RequestHandlerVariant[];
 };
 
 
-function _tupleByMiddlewareName(handler: RequestHandler): [ string, RequestHandler ] {
+function _tupleByMiddlewareName(handler: RequestHandlerVariant): [ string, RequestHandlerVariant ] {
   // keyed by the names Express would give them
   return [ handler.name, handler ];
 }
@@ -97,7 +97,7 @@ const MORGAN_LOGGER = morgan(_morganFormatter, {
 const WITHJOY_DOMAIN_REGEX = /\.withjoy\.com$/;
 
 export function getDefaultMiddleware(): DefaultMiddlewareResult {
-  const preludesMap = new Map<string, RequestHandler>([
+  const preludesMap = new Map<string, RequestHandlerVariant>([
     cors({
       origin: function(originProvided, callback) {
         // // FIXME:  the right thing to do
@@ -125,13 +125,13 @@ export function getDefaultMiddleware(): DefaultMiddlewareResult {
     MORGAN_LOGGER,
   ].map(_tupleByMiddlewareName));
 
-  const bodyParsersMap = new Map<string, RequestHandler>([
+  const bodyParsersMap = new Map<string, RequestHandlerVariant>([
     // calling out the default(s) -- @see https://github.com/expressjs/body-parser#bodyparserjsonoptions
     bodyParser.json({ limit: '100Kb' }),
     bodyParser.urlencoded({ extended: false }),
   ].map(_tupleByMiddlewareName));
 
-  const apolloMap = new Map<string, RequestHandler>([
+  const apolloMap = new Map<string, RequestHandlerVariant>([
     bodyParserGraphql({ limit: '100Kb' }),
   ].map(_tupleByMiddlewareName));
 

--- a/src/middleware/error.logging.ts
+++ b/src/middleware/error.logging.ts
@@ -6,12 +6,7 @@ import {
   pick,
   pickBy,
 } from 'lodash';
-import {
-  Request,
-  Response,
-  NextFunction,
-  ErrorRequestHandler,
-} from 'express'
+import { Request, Response, NextFunction, ErrorRequestHandler } from 'express'
 import { ApolloServerPlugin, GraphQLRequestListener } from 'apollo-server-plugin-base';
 import {
   Telemetry,

--- a/src/middleware/session.ts
+++ b/src/middleware/session.ts
@@ -2,9 +2,16 @@ import cookie from 'cookie';
 import { Request, Response, NextFunction, RequestHandler } from 'express'
 import { randomBytes } from 'crypto';
 
+
 export const SESSION_COOKIE_NAME: string = 'joy_session_id';
 export const SESSION_REQUEST_PROPERTY: string = 'sessionId';
 export const SESSION_HEADER_NAME = 'x-joy-sessionid';
+
+export interface RequestWithSessionID extends Request {
+  // `[ SESSION_REQUEST_PROPERTY ]` => "A computed property name in an interface ... ts(1169)"
+  sessionId?: string;
+}
+
 
 // we don't want cookie to expire, so set expiration time as far as possible
 // in the future without risking unexpected results due to bugs
@@ -12,7 +19,7 @@ const FAR_FUTURE_EXPIRES: string = 'Sun, 3 Jan 2038 00:00:00 GMT';
 const FAR_FUTURE_MAX_AGE: number = 157680000; // ~5 years, so not tickling limits until 1/2033
 
 interface SessionOptions {
-    passive: boolean;   // middleware does not create a new session if none exists
+  passive: boolean;   // middleware does not create a new session if none exists
 }
 
 function _makeSessionId(): string {
@@ -22,6 +29,7 @@ function _makeSessionId(): string {
   // but we're not trying to "conserve String length" or do any special encoding, so i think 'hex' is sufficient
   return randomBytes(24).toString('hex')
 }
+
 
 export function generateSessionIdSetCookieHeaderValue(sessionId: string): string {
   return cookie.serialize(SESSION_COOKIE_NAME, sessionId, {
@@ -49,9 +57,8 @@ export function sessionMiddleware(maybeOptions?: SessionOptions): RequestHandler
     passive: false,
     ...maybeOptions
   }
-  return function sessionMiddleware(req: Request, res: Response, next: NextFunction): void {
+  return function sessionMiddleware(req: RequestWithSessionID, res: Response, next: NextFunction): void {
     const { headers } = req;
-    const reqAsAny: any = <any>req;
 
     const cookies = cookie.parse(headers['cookie'] || '');
     const cookieSessionId = (cookies || {})[SESSION_COOKIE_NAME];
@@ -62,8 +69,11 @@ export function sessionMiddleware(maybeOptions?: SessionOptions): RequestHandler
       req.headers[SESSION_HEADER_NAME] = sessionId;
     }
 
-    if (sessionId) {
-      reqAsAny[SESSION_REQUEST_PROPERTY] = sessionId;
+    if (Array.isArray(sessionId)) {
+      req.sessionId = sessionId[0];
+    }
+    else if (sessionId) {
+      req.sessionId = sessionId;
     }
 
     next();

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -1,0 +1,6 @@
+import { RequestHandler, ErrorRequestHandler } from 'express';
+
+// support:
+//   handler(req, res, next)
+//   handler(err, req, res, next)
+export type RequestHandlerVariant = RequestHandler | ErrorRequestHandler;

--- a/src/server/server.init.ts
+++ b/src/server/server.init.ts
@@ -110,3 +110,23 @@ export const initApp = async (app: IServer, port: number): Promise<void> => {
       process.exit(1);
     });
 }
+
+/**
+  * This triggers the 'graceful shutdown' mechanism of `initApp` (above).
+  *
+  * It makes sure that we stop accepting new connections
+  * and wait for current requests to finish before stopping the process.
+  */
+export function shutdownCurrentApp() {
+  const commonLogInfo = commonLogInformation();
+
+  // 'SIGINT' and 'SIGTERM' are both handled by `initApp` to do graceful shutdowns;
+  //   however, 'SIGTERM' seems most appropriate
+  //   per [signal best practices](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html)
+  process.kill(process.pid, 'SIGTERM');
+
+  telemetry.info('shutdownCurrentApp', {
+    ...commonLogInfo,
+    action: 'shutdown',
+  });
+}


### PR DESCRIPTION
- this pattern works: `interface RequestWithSessionId extends Request`
- `type RequestHandlerVariant`, so that middleware supports ErrorRequestHandler
- `shutdownCurrentApp`, formalizing the SIGTERM approach