### PR TITLE
CORE-1608 shift Health Checks into '@withjoy/server-core'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,16 @@
 /* istanbul ignore file */
 
+/*
+  the following toolkits are path-referenced
+    'utils/healthCheck'
+    'utils/pg'
+    'utils/typeorm'
+  please use
+  ```
+  import { ... } from '@withjoy/server-core/dist/<PATH>';
+  ```
+*/
+
 import { VERSION } from './utils/const';
 import {
   Context,

--- a/src/utils/healthCheck/index.ts
+++ b/src/utils/healthCheck/index.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+
+export * from './postgres';
+export * from './requestHandler';
+export * from './typeormMigrations';
+export * from './types';
+export * from './utils';

--- a/src/utils/healthCheck/postgres.spec.ts
+++ b/src/utils/healthCheck/postgres.spec.ts
@@ -1,0 +1,7 @@
+import { noop } from 'lodash';
+
+describe('utils/healthCheck', () => {
+  describe('healthCheckerPostgres', () => {
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
+  });
+});

--- a/src/utils/healthCheck/postgres.ts
+++ b/src/utils/healthCheck/postgres.ts
@@ -1,0 +1,31 @@
+/* istanbul ignore file */
+//   it('is covered in @withjoy/server-core-test, with a backing database', noop);
+
+import { getConnection } from 'typeorm';
+import { isNumber } from 'lodash';
+import { deriveTelemetryContextFromError } from '@withjoy/telemetry';
+
+import { Context } from '../../server/apollo.context';
+
+
+export async function healthCheckerPostgres(context: Context): Promise<boolean> {
+  const { telemetry } = context;
+
+  try {
+    // Posgres should be able to tell us its current time-of-day
+    // FUTURE:  use Postgres as a reliable source-of-truth RE: server time
+    const results = await getConnection().query('SELECT FLOOR(EXTRACT(epoch FROM now()) * 1000) AS milliseconds');
+    if (! isNumber(results[0].milliseconds)) {
+      throw new Error('Postgres cannot provide the current time');
+    }
+    return true;
+  }
+  catch (error) {
+    telemetry.error('healthCheckerPostgres: failure', {
+      ...deriveTelemetryContextFromError(error),
+      source: 'healthCheck',
+      action: 'postgres',
+    });
+    return false;
+  }
+}

--- a/src/utils/healthCheck/requestHandler.spec.ts
+++ b/src/utils/healthCheck/requestHandler.spec.ts
@@ -1,0 +1,198 @@
+import {
+  createSandbox,
+  expectation,
+  match as sinonMatcher,
+  SinonExpectation,
+  SinonMock,
+} from 'sinon';
+import { noop } from 'lodash';
+import {
+  createRequest,
+  createResponse,
+  MockRequest,
+  MockResponse,
+} from 'node-mocks-http';
+import { Request, Response } from 'express';
+
+import { Context, injectContextIntoRequestMiddleware } from '../../server/apollo.context';
+import { HealthCheckState } from './utils';
+import { HealthChecker } from './types';
+import {
+  createHealthCheckRequestHandler,
+} from './requestHandler';
+
+const CONTEXT = new Context();
+const CONTEXT_MIDDLEWARE = injectContextIntoRequestMiddleware(() => CONTEXT);
+function _injectContext(req: Request, res: Response) {
+  CONTEXT_MIDDLEWARE(req, res, noop);
+}
+
+const NO_CHECKERS = Object.freeze({ checkers: {} });
+const GOOD = new HealthCheckState();
+const BAD = new HealthCheckState();
+BAD.set(false);
+const BOOM_CHECKER: HealthChecker = () => Promise.reject(new Error('BOOM'));
+
+
+describe('utils/healthCheck', () => {
+  const sandbox = createSandbox();
+
+  afterEach(() => {
+    sandbox.verifyAndRestore();
+  });
+
+
+  describe('createHealthCheckRequestHandler', () => {
+    let req: MockRequest<Request>;
+    let res: MockResponse<Response>;
+    let next: SinonExpectation;
+    let telemetryMock: SinonMock;
+
+    beforeEach(() => {
+      req = createRequest();
+      res = createResponse();
+
+      next = expectation.create();
+      next.never(); // happy-path
+
+      telemetryMock = sandbox.mock(CONTEXT.telemetry);
+      telemetryMock.expects('error').never(); // happy-path
+    });
+
+
+    it('succeeds with a successful check', async () => {
+      const requestHandler = createHealthCheckRequestHandler({
+        checkers: {
+          success: GOOD.healthChecker,
+        },
+      });
+      _injectContext(req, res);
+      await requestHandler(req, res, next);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getData()).toBe(JSON.stringify({
+        success: true,
+      }));
+    });
+
+    it('fails with any one failing check', async () => {
+      const requestHandler = createHealthCheckRequestHandler({
+        checkers: {
+          success: GOOD.healthChecker,
+          good: GOOD.healthChecker,
+          bad: BAD.healthChecker,
+        },
+      });
+      _injectContext(req, res);
+      await requestHandler(req, res, next);
+
+      expect(res._getStatusCode()).toBe(500);
+      expect(res._getData()).toBe(JSON.stringify({
+        success: true,
+        good: true,
+        bad: false,
+      }));
+    });
+
+    it('fails when a check throws', async () => {
+      // it('logs the Error')
+      telemetryMock.expects('error').once().withArgs(
+        'requestHandler: failure',
+        sinonMatcher({
+          error: {
+            message: sinonMatcher(/BOOM/),
+          },
+          key: 'boom',
+        })
+      );
+
+      const requestHandler = createHealthCheckRequestHandler({
+        checkers: {
+          success: GOOD.healthChecker,
+          boom: BOOM_CHECKER,
+        },
+      });
+      _injectContext(req, res);
+      await requestHandler(req, res, next);
+
+      expect(res._getStatusCode()).toBe(500);
+      expect(res._getData()).toBe(JSON.stringify({
+        // it('still performs all the checks')
+        success: true,
+        boom: false,
+      }));
+    });
+
+
+    it('expects a Context in the Request', async () => {
+      // it('hands the Error up the middleware chain')
+      next.once().withArgs( sinonMatcher(Error) );
+
+      const requestHandler = createHealthCheckRequestHandler(NO_CHECKERS);
+      // no _injectContext
+      await requestHandler(req, res, next);
+    });
+
+    it('succeeds with no checkers', async () => {
+      const requestHandler = createHealthCheckRequestHandler(NO_CHECKERS);
+      _injectContext(req, res);
+      await requestHandler(req, res, next);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getData()).toBe('{}');
+    });
+
+    it('responds with a custom status code upon success', async () => {
+      const requestHandler = createHealthCheckRequestHandler({
+        checkers: {},
+        successStatusCode: 302,
+      });
+      _injectContext(req, res);
+      await requestHandler(req, res, next);
+
+      expect(res._getStatusCode()).toBe(302);
+      expect(res._getData()).toBe('{}');
+    });
+
+    it('responds with a custom status code upon failure', async () => {
+      const requestHandler = createHealthCheckRequestHandler({
+        checkers: {
+          bad: BAD.healthChecker,
+        },
+        failureStatusCode: 418,
+      });
+      _injectContext(req, res);
+      await requestHandler(req, res, next);
+
+      expect(res._getStatusCode()).toBe(418);
+      expect(res._getData()).toBe(JSON.stringify({
+        bad: false,
+      }));
+    });
+
+    it('does not let non-critical checks fail the aggregate', async () => {
+      // it('logs the Error')
+      telemetryMock.expects('error').once();
+
+      const requestHandler = createHealthCheckRequestHandler({
+        checkers: {
+          success: GOOD.healthChecker,
+          bad: BAD.healthChecker,
+          boom: BOOM_CHECKER,
+        },
+        nonCritical: [ 'bad', 'boom' ],
+      });
+      _injectContext(req, res);
+      await requestHandler(req, res, next);
+
+      // it('sure seems happy')
+      expect(res._getStatusCode()).toBe(200);
+      // it('is, in fact, quite unhappy')
+      expect(res._getData()).toBe(JSON.stringify({
+        success: true,
+        bad: false,
+        boom: false,
+      }));
+    });
+  });
+});

--- a/src/utils/healthCheck/requestHandler.ts
+++ b/src/utils/healthCheck/requestHandler.ts
@@ -1,0 +1,51 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+import { deriveTelemetryContextFromError } from "@withjoy/telemetry";
+
+import { Context, deriveContextFromRequest } from '../../server/apollo.context';
+import { HealthCheckRequestHandlerOptions } from './types';
+
+
+export function createHealthCheckRequestHandler<T extends Context = Context>(
+  options: HealthCheckRequestHandlerOptions<T>
+): RequestHandler {
+  const { checkers } = options;
+  const successStatusCode = options.successStatusCode || 200;
+  const failureStatusCode = options.failureStatusCode || 500;
+  const nonCritical = new Set(options.nonCritical || []);
+
+  const requestHandler: RequestHandler = async(req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const context = deriveContextFromRequest(req) as T;
+    if (! context) {
+      next(new Error('createHealthCheckRequestHandler: request has no Context'));
+      return;
+    }
+
+    const resultsByKey: Record<string, boolean> = {};
+    await Promise.all(Object.keys(checkers).map(async (key) => {
+      const checker = checkers[key];
+      try {
+        resultsByKey[key] = await checker(context);
+      }
+      catch (error) {
+        // this is *not* expected;
+        //   each Health Checker should catch, log and absorb its own Errors
+        context.telemetry.error('requestHandler: failure', {
+          ...deriveTelemetryContextFromError(error),
+          source: 'healthCheck',
+          action: 'requestHandler',
+          key,
+        });
+        resultsByKey[key] = false;
+      }
+    }));
+
+    // non-critical checks do not impact the aggregate
+    const aggregate = Object.keys(resultsByKey).every((key) =>
+      (nonCritical.has(key) || resultsByKey[key] || false)
+    );
+    const payload = JSON.stringify(resultsByKey);
+    res.status(aggregate ? successStatusCode : failureStatusCode).send(payload);
+  }
+
+  return requestHandler;
+}

--- a/src/utils/healthCheck/typeormMigrations.spec.ts
+++ b/src/utils/healthCheck/typeormMigrations.spec.ts
@@ -1,0 +1,7 @@
+import { noop } from 'lodash';
+
+describe('utils/healthCheck', () => {
+  describe('healthCheckerTypeormMigrations', () => {
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
+  });
+});

--- a/src/utils/healthCheck/typeormMigrations.ts
+++ b/src/utils/healthCheck/typeormMigrations.ts
@@ -1,0 +1,38 @@
+/* istanbul ignore file */
+//   it('is covered in @withjoy/server-core-test, with a backing database', noop);
+
+import { difference } from 'lodash';
+import { getConnection } from 'typeorm';
+import { Migration } from 'typeorm/migration/Migration';
+import { MigrationExecutor } from 'typeorm/migration/MigrationExecutor';
+import { deriveTelemetryContextFromError } from "@withjoy/telemetry";
+
+import { Context } from '../../server/apollo.context';
+
+
+export async function healthCheckerTypeormMigrations(context: Context): Promise<boolean> {
+  const { telemetry } = context;
+
+  try {
+    const connection = getConnection();
+    const allMigrationNames = connection.migrations.map((migrationScript) => migrationScript.constructor.name);
+
+    const migrationExecutor: MigrationExecutor = new MigrationExecutor(connection);
+    const executedMigrations: Migration[] = await (<any>migrationExecutor).loadExecutedMigrations(); // de-protected method
+    const executedMigrationNames = executedMigrations.map((migration) => migration.name);
+
+    const unexecuted = difference(allMigrationNames, executedMigrationNames);
+    if (unexecuted.length !== 0) {
+      throw new Error(`unexecuted TypeORM Migrations: ${ JSON.stringify(unexecuted) }`);
+    }
+    return true;
+  }
+  catch (error) {
+    telemetry.error('healthCheckerTypeormMigrations: failure', {
+      ...deriveTelemetryContextFromError(error),
+      source: 'healthCheck',
+      action: 'typeormMigrations',
+    });
+    return false;
+  }
+}

--- a/src/utils/healthCheck/types.ts
+++ b/src/utils/healthCheck/types.ts
@@ -7,8 +7,20 @@ export interface HealthCheckProvider<T extends Context = Context> {
 };
 
 export type HealthCheckRequestHandlerOptions<T extends Context = Context> = {
+  // everything that should get checked;
+  //   each HealthChecker is checked independently; any single failure doesn't impact the others.
+  //   the HTTP payload returned by the endpoint will be a `Record<string, boolean>` of the results
   checkers: Record<string, HealthChecker<T>>;
+  // the HTTP endpoint returns this status code when
+  //   all of the `HealthChecker`s pass / resolve `true`
   successStatusCode?: number;
+  // the HTTP endpoint returns this status code when
+  //   any of the `HealthChecker`s fail / throw / resolve `false`.
+  //   you can modify this status code to mask the failure.
+  //   (eg. `200` = run all the checks, output an accurate payload, but don't report a failure status)
+  //   (it's like marking *everything* as `{ nonCritical }`)
   failureStatusCode?: number;
+  // keys in `{ checkers }` which are allowed to fail
+  //   the check is run, and it is accurate in the payload, but it doesn't impact aggregate status
   nonCritical?: string[], // <keyof this.checkers>[]
 };

--- a/src/utils/healthCheck/types.ts
+++ b/src/utils/healthCheck/types.ts
@@ -1,0 +1,14 @@
+import { Context } from '../../server/apollo.context';
+
+export type HealthPredicate = () => Promise<boolean>;
+export type HealthChecker<T extends Context = Context> = (context: T) => Promise<boolean>;
+export interface HealthCheckProvider<T extends Context = Context> {
+  healthChecker: HealthChecker<T>;
+};
+
+export type HealthCheckRequestHandlerOptions<T extends Context = Context> = {
+  checkers: Record<string, HealthChecker<T>>;
+  successStatusCode?: number;
+  failureStatusCode?: number;
+  nonCritical?: string[], // <keyof this.checkers>[]
+};

--- a/src/utils/healthCheck/utils.spec.ts
+++ b/src/utils/healthCheck/utils.spec.ts
@@ -1,0 +1,75 @@
+import {
+  createSandbox,
+  match as sinonMatcher,
+  SinonMock,
+} from 'sinon';
+
+import { Context } from '../../server/apollo.context';
+import {
+  HealthCheckState,
+  healthCheckForPredicate,
+} from './utils';
+
+
+const CONTEXT = new Context();
+
+describe('utils/healthCheck', () => {
+  const sandbox = createSandbox();
+  let telemetryMock: SinonMock;
+
+  beforeEach(() => {
+    telemetryMock = sandbox.mock(CONTEXT.telemetry);
+    telemetryMock.expects('error').never(); // happy-path
+  });
+
+  afterEach(() => {
+    sandbox.verifyAndRestore();
+  });
+
+
+  describe('HealthCheckState', () => {
+    it('is dead simple', async () => {
+      const state = new HealthCheckState();
+
+      // it('is assumed healthy')
+      expect(state.value).toBe(true);
+      expect(await state.healthChecker()).toBe(true);
+
+      // it('becomes unhealthy')
+      state.set(false);
+
+      expect(state.value).toBe(false);
+      expect(await state.healthChecker()).toBe(false);
+    });
+  });
+
+
+  describe('healthCheckForPredicate', () => {
+    it('succeeds', async () => {
+      const healthChecker = healthCheckForPredicate(() => Promise.resolve(true));
+      expect(await healthChecker(CONTEXT)).toBe(true);
+    });
+
+    it('fails', async () => {
+      const healthChecker = healthCheckForPredicate(() => Promise.resolve(false));
+      expect(await healthChecker(CONTEXT)).toBe(false);
+    });
+
+    it('fails with an Error', async () => {
+      // it('logs the Error')
+      telemetryMock.expects('error').once().withArgs(
+        'healthCheckForPredicate: failure',
+        sinonMatcher({
+          error: {
+            message: sinonMatcher(/BOOM/),
+          },
+          predicate: 'namedPredicate',
+        })
+      );
+
+      const namedPredicate = () => Promise.reject(new Error('BOOM'));
+      const healthChecker = healthCheckForPredicate(namedPredicate);
+      expect(await healthChecker(CONTEXT)).toBe(false);
+    });
+  });
+});

--- a/src/utils/healthCheck/utils.ts
+++ b/src/utils/healthCheck/utils.ts
@@ -38,7 +38,7 @@ export class HealthCheckState
   // assumed healthy
   private _value: boolean = true;
   constructor() {
-    // easily detachable
+    // pre-bound, to support the simple syntax `{ checkers: { baz: stateOfBaz.healthChecker } }`
     this.healthChecker = this.healthChecker.bind(this);
   }
 

--- a/src/utils/healthCheck/utils.ts
+++ b/src/utils/healthCheck/utils.ts
@@ -1,0 +1,54 @@
+import { deriveTelemetryContextFromError } from "@withjoy/telemetry";
+
+import {
+  HealthPredicate,
+  HealthChecker,
+  HealthCheckProvider,
+} from './types';
+
+
+export function healthCheckForPredicate(healthPredicate: HealthPredicate): HealthChecker {
+  return async (context) => {
+    const { telemetry } = context;
+
+    try {
+      const healthy = await healthPredicate();
+      return healthy;
+    }
+    catch (error) {
+      telemetry.error('healthCheckForPredicate: failure', {
+        ...deriveTelemetryContextFromError(error),
+        source: 'healthCheck',
+        action: 'healthCheckForPredicate',
+        predicate: healthPredicate.name,
+      });
+      return false;
+    }
+  };
+}
+
+
+// singletons
+const TRUE = Promise.resolve(true);
+const FALSE = Promise.resolve(false);
+
+export class HealthCheckState
+  implements HealthCheckProvider
+{
+  // assumed healthy
+  private _value: boolean = true;
+  constructor() {
+    // easily detachable
+    this.healthChecker = this.healthChecker.bind(this);
+  }
+
+  get value() {
+    return this._value;
+  }
+  set(value: boolean): void {
+    this._value = value;
+  }
+  healthChecker(): Promise<boolean> {
+    return (this._value ? TRUE : FALSE);
+  }
+}

--- a/src/utils/pg/index.spec.ts
+++ b/src/utils/pg/index.spec.ts
@@ -8,18 +8,18 @@ describe('utils/pg', () => {
   //   so ...
 
   describe('pgInlineParametersIntoQuery', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('pgDeriveQueryBuilderStatements', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('pgCombineStatements', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('pgQueryBuilderBatchStatement', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 });

--- a/src/utils/pg/index.ts
+++ b/src/utils/pg/index.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-//   it('is covered in @withjoy/server-test-core, with a backing database', noop);
+//   it('is covered in @withjoy/server-core-test, with a backing database', noop);
 
 const { prepareValue: pgPrepareValue } = require('pg/lib/utils');
 import uuidV4 from 'uuid/v4';

--- a/src/utils/typeorm/batch.pg.spec.ts
+++ b/src/utils/typeorm/batch.pg.spec.ts
@@ -7,10 +7,10 @@ describe('utils/typeorm/batch.support', () => {
   //   so ...
 
   describe('TypeORMPostgresBatch', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('createTypeORMPostgresBatch', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 });

--- a/src/utils/typeorm/batch.pg.ts
+++ b/src/utils/typeorm/batch.pg.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-//   it('is covered in @withjoy/server-test-core, with a backing database', noop);
+//   it('is covered in @withjoy/server-core-test, with a backing database', noop);
 
 import { chunk, compact } from 'lodash';
 import uuidV4 from 'uuid/v4';

--- a/src/utils/typeorm/batch.support.spec.ts
+++ b/src/utils/typeorm/batch.support.spec.ts
@@ -7,38 +7,38 @@ describe('utils/typeorm/batch.support', () => {
   //   so ...
 
   describe('applyDefaultEntityValues', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('queryBuilderToInsertModels', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('queryBuildersToForceKeysOfModels', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('injectSequenceKeysIntoModels', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('queryBuilderToDeleteModelById', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('queryBuilderToDeleteModelsBySelectedIds', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('queryBuilderToDeleteModelsByParentId', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('queryBuildersToInsertManyToManyJunctions', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('queryBuildersToDeleteManyToManyJunctionsByParentId', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 });

--- a/src/utils/typeorm/batch.support.ts
+++ b/src/utils/typeorm/batch.support.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-//   it('is covered in @withjoy/server-test-core, with a backing database', noop);
+//   it('is covered in @withjoy/server-core-test, with a backing database', noop);
 
 import {
   compact,

--- a/src/utils/typeorm/helpers.spec.ts
+++ b/src/utils/typeorm/helpers.spec.ts
@@ -30,6 +30,6 @@ describe('util/typeorm/helpers', () => {
       expect(hasEntityBeenPersisted(null)).toBe(false);
     });
 
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 });

--- a/src/utils/typeorm/index.ts
+++ b/src/utils/typeorm/index.ts
@@ -1,6 +1,6 @@
-// everything we should export under the `typeorm` namespace
+/* istanbul ignore file */
+//   it('is covered in @withjoy/server-core-test, with a backing database', noop);
+
 export * from './batch.support';
 export * from './batch.pg';
 export * from './migration';
-
-// the rest should be treated as a top-level exports

--- a/src/utils/typeorm/migration.spec.ts
+++ b/src/utils/typeorm/migration.spec.ts
@@ -7,10 +7,10 @@ describe('utils/typeorm/migration', () => {
   //   so ...
 
   describe('migrateWithPostgresSettings', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 
   describe('migrateWithoutTransaction', () => {
-    it('is covered in @withjoy/server-test-core, with a backing database', noop);
+    it('is covered in @withjoy/server-core-test, with a backing database', noop);
   });
 });

--- a/src/utils/typeorm/migration.ts
+++ b/src/utils/typeorm/migration.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-//   it('is covered in @withjoy/server-test-core, with a backing database', noop);
+//   it('is covered in @withjoy/server-core-test, with a backing database', noop);
 
 import { QueryRunner } from 'typeorm';
 const { prepareValue: pgPrepareValue } = require('pg/lib/utils');


### PR DESCRIPTION
- check for Postgres health
- check for un-applied TypeORM Migrations
- called out path-referenced toolkits (vs. part of formal exports)
- end-to-end database Test Cases live in '@withjoy/server-core-test'
- HealthCheckState as a convenient 'latch'
- simple "predicate" check wrapper for any `async` boolean Function
- 'prior me' couldn't spell "@withjoy/server-core-test" properly