### PR TITLE
graphql code generator friendly core types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withjoy/server-core",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "description": "Joy Server Base and Utils",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/graphql/core.types.ts
+++ b/src/graphql/core.types.ts
@@ -15,7 +15,7 @@ const REGEX_FORMAT = /^\d{4}-\d{2}-\d{2}$/
 //   @see `scalar Timestamp`
 const FORMAT_TIMESTAMP = 'YYYY-MM-DD[T]HH:mm:ss.SSSZ';
 
-export const coreTypeDefs = gql`
+const coreTypeDefsString = /* GraphQL */ `
 
   scalar JSONObject
 
@@ -89,6 +89,7 @@ export const coreTypeDefs = gql`
 
 `;
 
+export const coreTypeDefs = gql(coreTypeDefsString);
 
 type _CoreTypeDateTuple = [ string, string ] | string;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "removeComments": true,
+    "removeComments": false,
     "strict": true,
     "strictPropertyInitialization": false,
     "moduleResolution": "node",


### PR DESCRIPTION
Reason for change: 
In order for `graphql-code-generator` to identify graphlq types it needs an identifier wrapping the string. `gql` typically works but when the files are compiled with `tsc` the wrapper changes to `apollo_server_1.gql`. Moving the graphql types to a string with a `/* GraphQL */` comment accomplishes the same thing and wrapping this string in `gql` keeps everything the same as far as the exported object.