### PR TITLE
REG-2024 | Change executeOperationsInParallel to be more efficient

### DIFF
--- a/src/utils/miscellaneous.spec.ts
+++ b/src/utils/miscellaneous.spec.ts
@@ -78,5 +78,30 @@ describe('utils/miscellaneous', () => {
       ]);
       expect(iteratorItems).toBe(ITEMS);
     });
+
+    it('Executes efficiently', async () => {
+      const timeoutPromise = (sideEffect: (ms: number) => void) => (ms: number) =>
+        new Promise((res) => setTimeout(res, ms, ms))
+          .then(((ms: number) => sideEffect(ms)) as any)
+      const evidence: number[] = [];
+      const times = [1, 1000, 2, 3];
+      await executeOperationsInParallel(
+        times,
+        timeoutPromise((ms) => evidence.push(ms))
+      );
+      // it("counts to 1000")
+      expect(evidence).toMatchObject([1,2,3,1000]);
+    });
+
+    it('Safely skips and returns null for errors', async () => {
+      const results = await executeOperationsInParallel(ITEMS, async (item) => {
+        if(item === 4 || item === 13) {
+          throw Error("Unlucky number detected!");
+        }
+        return item;
+      })
+      expect(results[4]).toBe(null);
+      expect(results[13]).toBe(null);
+    });
   });
 });

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -19,24 +19,59 @@ const EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS: Required<IExecuteOperations
   batchSize: 8,
 };
 
+/*
+  We want each promise to either
+    * spawn a new promise or
+    * terminate.
+  We want this to happen even if there is an error during execution.
+  Eg for batchSize = 4 we will do something like:
+    () => () => null
+    () => () => () => null
+    () => null
+    () => () => null
+  Where each () represents a unit of work.
+  Finally, because we don't know what will finish when,
+  we need to store results in a map and sort it out at the end.
+*/
 export async function executeOperationsInParallel<T = any, U = any>(
   items: T[],
   operation: (item: T, index: number, array: T[]) => Promise<U>,
   options?: IExecuteOperationsInParallelOptions
 ): Promise<U[]> {
+  // begin with a wall of `batchSize` promises
   const batchSize = options?.batchSize || EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS.batchSize;
-  const batches = chunk(items, batchSize);
-  let results: U[] = [];
+  const initialBatch = items.slice(0, batchSize);
 
-  for (let batch of batches) {
-    const priorCount = results.length;
-    const result = await Promise.all(batch.map((item, index) => {
-      // iteration arguments relative to the entire set of items
-      //   vs. this particular batch
-      return operation(item, (priorCount + index), items);
-    }));
-    results = results.concat(result);
+  // when a promise finishes it will:
+  // * store a result
+  // * pull from the queue
+  // * increment the index
+  let workQueue = items.slice(batchSize);
+  let currentIndex = batchSize;
+  let results: any = {};
+
+  // A recursion in two parts,
+  // each function will call the other after each promise
+  // until `storeAndTryNext` terminates the process by returning `null`
+
+  // * do the operation
+  // * whether we succeed or not, try to pull again from the queue
+  const work = (item: T, index: number) => operation(item, index, items)
+        .then(nextResult => storeAndTryNext(nextResult, index))
+        .catch((_e:any) => storeAndTryNext(null, index))
+
+  // * store the indexed result
+  // * if we're out of work end the chain by returning null
+  // * otherwise recurse on work()
+  const storeAndTryNext = (result: U | null, index: number): Promise<U | null> | null => {
+    results[index] = result;
+    if(workQueue.length === 0) { return null; }
+    return work(workQueue.shift()!, currentIndex++);
   }
-
-  return results;
+  // start the promise wall and wait for it to finish
+  let promiseGroup = initialBatch.map((item, index) => work(item, index));
+  await Promise.all(promiseGroup);
+  return Object.keys(results)
+    .sort((a,b) => parseInt(a, 10) - parseInt(b, 10))
+    .map(key => results[key]);
 }


### PR DESCRIPTION
The function will now behave like a pool,
instead of waiting for all items in a batch to finish.