### PR TITLE
CHORE introduce Void GraphQL Scalar type

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,10 @@ module.exports = {
   coverageReporters: ['json', 'lcov', 'text'],
   coverageThreshold: {
     global: {
-      statements: 85.4,
-      branches: 83.5,
-      functions: 75.9,
-      lines: 86.3,
+      statements: 86.2,
+      branches: 83.9,
+      functions: 77.3,
+      lines: 87.0,
     },
   },
   globals: {

--- a/src/graphql/core.types.ts
+++ b/src/graphql/core.types.ts
@@ -1,6 +1,7 @@
 import { gql, IResolvers } from 'apollo-server';
 import moment, { Moment } from 'moment-timezone';
 import chroma, { Color } from 'chroma-js';
+import { GraphQLScalarType } from 'graphql';
 import { GraphQLJSONObject } from 'graphql-type-json';
 
 import { Context } from 'src/server/apollo.context';
@@ -18,6 +19,7 @@ const FORMAT_TIMESTAMP = 'YYYY-MM-DD[T]HH:mm:ss.SSSZ';
 const coreTypeDefsString = /* GraphQL */ `
 
   scalar JSONObject
+  scalar Void
 
   type Color {
     hex: String!
@@ -90,6 +92,15 @@ const coreTypeDefsString = /* GraphQL */ `
 `;
 
 export const coreTypeDefs = gql(coreTypeDefsString);
+
+const resolveNull = () => null;
+const Void: GraphQLScalarType = new GraphQLScalarType({
+  name: 'Void',
+  description: 'The `Void` scalar type always resolves null.',
+  serialize: resolveNull,
+  parseValue: resolveNull,
+  parseLiteral: resolveNull,
+});
 
 type _CoreTypeDateTuple = [ string, string ] | string;
 
@@ -264,6 +275,7 @@ export function parseCoreTypeInputDateAndTimezone(date: string | null | undefine
 
 export const coreResolvers: IResolvers = {
   JSONObject: GraphQLJSONObject,
+  Void,
 
   Date: {
     timestamp: (date: _CoreTypeDateTuple): string => {

--- a/test/apollo/core.types.jsonObject.ts
+++ b/test/apollo/core.types.jsonObject.ts
@@ -1,7 +1,7 @@
 import { gql } from 'apollo-server-core';
 import { isEqual } from 'lodash';
 
-import { coreTypeDefs } from '../../src/graphql/core.types';
+import { coreTypeDefs, coreResolvers } from '../../src/graphql/core.types';
 import { testSetupApollo } from '../helpers/apollo';
 
 
@@ -31,6 +31,7 @@ describe('the GraphQL JSONObject TypeDefs', () => {
           QUERY_TYPEDEFS,
         ],
         resolvers: {
+          ...coreResolvers,
           Query: {
             jsonQuery: () => resolved,
           },
@@ -53,7 +54,7 @@ describe('the GraphQL JSONObject TypeDefs', () => {
       });
     });
 
-    it('resolves a non-Object payload, regardless of its scalar Type name', async () => {
+    it('cannot serialize a non-Object payload', async () => {
       const { query } = client;
       resolved = STRING;
 
@@ -61,9 +62,15 @@ describe('the GraphQL JSONObject TypeDefs', () => {
         query: QUERY,
       });
 
-      const { data } = res;
-      expect(data).toMatchObject({
-        jsonQuery: resolved,
+      expect(res).toMatchObject({
+        errors: [
+          {
+            message: /cannot represent non-object value/,
+          }
+        ],
+        data: {
+          jsonQuery: null,
+        },
       });
     });
 
@@ -114,6 +121,7 @@ describe('the GraphQL JSONObject TypeDefs', () => {
           `,
         ],
         resolvers: {
+          ...coreResolvers,
           Mutation: {
             jsonMutation: (_self: any, args: { actual: any }, _context: any) => {
               return isEqual(args.actual, expected);
@@ -142,7 +150,7 @@ describe('the GraphQL JSONObject TypeDefs', () => {
       });
     });
 
-    it('takes a non-Object payload, regardless of its scalar Type name', async () => {
+    it('cannot parse a non-Object payload', async () => {
       const { mutate } = client;
       expected = STRING;
 
@@ -154,9 +162,13 @@ describe('the GraphQL JSONObject TypeDefs', () => {
         `,
       });
 
-      const { data } = res;
-      expect(data).toMatchObject({
-        jsonMutation: true,
+      expect(res).toMatchObject({
+        errors: [
+          {
+            message: /cannot represent non-object value/,
+          }
+        ],
+        data: undefined,
       });
     });
 

--- a/test/apollo/core.types.void.ts
+++ b/test/apollo/core.types.void.ts
@@ -1,0 +1,67 @@
+import { gql } from 'apollo-server-core';
+
+import { coreTypeDefs, coreResolvers } from '../../src/graphql/core.types';
+import { testSetupApollo } from '../helpers/apollo';
+
+
+describe('the GraphQL Void TypeDef', () => {
+  describe('for a Query', () => {
+    const QUERY = gql`
+      query {
+        voidQuery
+      }
+    `;
+    let client: { query: Function };
+    let resolved: any;
+
+    beforeEach(async () => {
+      const setup = await testSetupApollo({
+        typeDefs: [
+          coreTypeDefs,
+          gql`
+            type Query {
+              voidQuery: Void
+            }
+          `,
+        ],
+        resolvers: {
+          ...coreResolvers,
+          Query: {
+            voidQuery: (_: any, args: any) => {
+              return resolved;
+            },
+          },
+        },
+      });
+      client = setup.client;
+    });
+
+    it('resolves null', async () => {
+      const { query } = client;
+      resolved = null;
+
+      const res = await query({
+        query: QUERY,
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        voidQuery: null,
+      });
+    });
+
+    it('resolves null regardless of what the Resolver returns', async () => {
+      const { query } = client;
+      resolved = 'SOMETHING NOT NULL';
+
+      const res = await query({
+        query: QUERY,
+      });
+
+      const { data } = res;
+      expect(data).toMatchObject({
+        voidQuery: null,
+      });
+    });
+  });
+});


### PR DESCRIPTION
- found out why our JSONObject Test Suite was mistakenly passing