### PR TITLE
REG-2252 adopt BatchPipelineExecutor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,9 +87,19 @@ import { loadDotEnv, configStringToBoolean, deriveConfigFeatureFlags } from './u
 import { createGraphQLEnumValues } from './utils/graphql.enum';
 import { EdgeWrapper, edgeWrapperType } from './utils/edge.wrapper';
 import {
+  ParallelOperation,
+  ParallelExecutorOptions,
+  executeOperationsInParallel,
+} from './utils/execution/parallel';
+import {
+  BatchPipelineOperation,
+  BatchPipelineExecutor,
+  BatchPipelineExecutorOptions,
+  executeOperationsInBatches,
+} from './utils/execution/batch';
+import {
   NULL_STRING,
   isUUID,
-  executeOperationsInParallel,
 } from './utils/miscellaneous';
 import { hasEntityBeenPersisted } from './utils/typeorm/helpers';
 import { logTypeORMConfig } from './utils/typeorm/logging';
@@ -231,9 +241,16 @@ export {
   EdgeWrapper,
   edgeWrapperType,
 
+  ParallelOperation,
+  ParallelExecutorOptions,
+  executeOperationsInParallel,
+  BatchPipelineOperation,
+  BatchPipelineExecutor,
+  BatchPipelineExecutorOptions,
+  executeOperationsInBatches,
+
   NULL_STRING,
   isUUID,
-  executeOperationsInParallel,
 
   // `import * as pg from '@withjoy/server-core/dist/utils/pg'`
   //   because TypeScript definitions can't be exported in a namespace

--- a/src/server/apollo.context.ts
+++ b/src/server/apollo.context.ts
@@ -213,7 +213,7 @@ export class Context
   public readonly remoteAddress: string | undefined;
   public readonly isTrustedRequest: boolean;
 
-  //   "why readonly?  why not a getter?"
+  // "why readonly?  why not a getter?"
   //   https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-core/src/runHttpQuery.ts#L254
   //   "// TODO: We currently shallow clone the context for every request,"
   //   and their `cloneObject` doesn't seem to consider getters.
@@ -322,7 +322,7 @@ export class Context
 
     (this.isSuperAdmin as boolean) = getProperty(this.currentUser, 'superAdmin') || false;
     (this.isAuthenticated as boolean) = (this.userId && (this.userId !== NO_USER)) || false;
-    (this.isIdentifed as boolean) = (!! this.currentUser);
+    (this.isIdentifed as boolean) = Boolean(this.currentUser);
   }
 
   private _currentAuth0Id(): string | undefined {

--- a/src/utils/execution/batch.spec.ts
+++ b/src/utils/execution/batch.spec.ts
@@ -1,0 +1,625 @@
+import { createSandbox, SinonSpy } from 'sinon';
+import { noop } from 'lodash';
+
+import {
+  BatchPipelineOperation,
+  BatchPipelineExecutor,
+  BatchPipelineExecutorOptions,
+  executeOperationsInBatches,
+} from './execute';
+
+
+const sandbox = createSandbox();
+const POISON = -1;
+
+function _setupPipelineSink<T = number>(options?: BatchPipelineExecutorOptions<T> & {
+  poisonItem?: T,
+}) {
+  const sink: T[] = [];
+  const operation: BatchPipelineOperation<T> = async (items: T[]) => {
+    // do not execute synchronously;
+    //   we need fine-grained control over assertion timing
+    await Promise.resolve();
+
+    // under real-world conditions, one bad apple will spoil the whole batch
+    const poison = options?.poisonItem;
+    if ((poison !== undefined) && items.includes(poison)) {
+      throw new Error('POISON');
+    }
+
+    for (const item of items) {
+      sink.push(item);
+    }
+  };
+  const operationSpy = sandbox.spy(operation);
+
+  const executor = new BatchPipelineExecutor(operationSpy, options);
+  return {
+    executor,
+    sink,
+    operationSpy,
+  }
+}
+
+async function _allowExecution() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function _teardownPipelineSink<T>(executor: BatchPipelineExecutor<T>) {
+  // any Error scenario queued up into the Executor must be handled by the caller
+  //   ... except cordoning.  we can FTFY
+  executor._items.length = 0;
+  executor._unreportedErrors.length = 0;
+  await executor.flush();
+}
+
+
+describe("Paginator", () => {
+  afterEach(() => {
+    sandbox.verifyAndRestore();
+  });
+
+
+  describe('executeOperationsInBatches', () => {
+    let sink: number[];
+    let operationSpy: SinonSpy;
+
+    beforeEach(() => {
+      sink = [];
+      operationSpy = sandbox.spy(async (items) => {
+        if (items.includes(POISON)) {
+          throw new Error('POISON');
+        }
+        sink = sink.concat(items);
+      });
+    });
+
+    it('executes in batches', async () => {
+      await executeOperationsInBatches([ 1, 2, 3, 4, 5 ], operationSpy, { batchSize: 3 });
+
+      expect(sink).toEqual([ 1, 2, 3, 4, 5 ]);
+      expect(operationSpy.callCount).toBe(2);
+    });
+
+    it('executes in batches', async () => {
+      await executeOperationsInBatches([ 1, 2, 3, 4, 5 ], operationSpy, { batchSize: 3 });
+
+      expect(sink).toEqual([ 1, 2, 3, 4, 5 ]);
+      expect(operationSpy.callCount).toBe(2);
+    });
+
+    describe('without an onError callback', () => {
+      it('rejects due to poison', async () => {
+        await expect(
+          executeOperationsInBatches([ 1, 2, 3, 4, POISON, 6, 7 ], operationSpy, { batchSize: 3 })
+        ).rejects.toThrow(/POISON/);
+
+        expect(sink).toEqual([ 1, 2, 3 ]);
+        expect(operationSpy.callCount).toBe(2);
+      });
+    });
+
+    describe('with an onError callback', () => {
+      it('notifies of Errors due to poison', async () => {
+        const onError = sandbox.spy();
+        await executeOperationsInBatches([ 1, 2, 3, 4, POISON, 6, 7 ], operationSpy, {
+          batchSize: 3,
+          onError,
+        });
+
+        expect(sink).toEqual([ 1, 2, 3, 7 ]);
+        expect(operationSpy.callCount).toBe(3);
+
+        expect(onError.callCount).toBe(1);
+        expect(onError.args[0][0].message).toMatch(/POISON/);
+        expect(onError.args[0][1]).toEqual([ 4, POISON, 6 ]);
+      });
+    });
+  });
+
+
+  describe('BatchPipelineOperation', () => {
+    describe('constructor', () => {
+      const OPERATION: BatchPipelineOperation<unknown> = async () => { /* void */ };
+
+      it('populates an instance', () => {
+        const onError = (_error: Error) => { /* no op */ };
+        const executor = new BatchPipelineExecutor(OPERATION, {
+          batchSize: 23,
+          onError,
+        });
+
+        expect(executor).toMatchObject({
+          isCordoned: false,
+          _options: {
+            batchSize: 23,
+            onError,
+          },
+          _items: [],
+          _activePromise: undefined,
+          _unreportedErrors: [],
+        });
+      });
+
+      it('falls back to defaults', () => {
+        const executor = new BatchPipelineExecutor(OPERATION);
+
+        expect(executor).toMatchObject({
+          isCordoned: false,
+          _options: {
+            batchSize: 8,
+            onError: undefined,
+          },
+          _items: [],
+          _activePromise: undefined,
+          _unreportedErrors: [],
+        });
+      });
+    });
+
+    describe('#push', () => {
+      it('triggers an execution once batchSize is reached', async () => {
+        const { executor } = _setupPipelineSink({ batchSize: 3 });
+
+        executor.push(1).push(2);
+        expect(executor._items).toEqual([ 1, 2 ]);
+        expect(executor._activePromise).toBeUndefined();
+
+        executor.push(3);
+        expect(executor._activePromise).not.toBeUndefined();
+
+        expect(executor._unreportedErrors.length).toBe(0);
+        await _teardownPipelineSink(executor);
+      });
+
+      it('will not push when the Executor is cordoned off', async () => {
+        const { executor } = _setupPipelineSink({ batchSize: 3 });
+
+        executor.push(1).cordon(true);
+        expect(executor.isCordoned).toBe(true);
+        expect(executor._items).toEqual([ 1 ]);
+        expect(executor._activePromise).toBeUndefined();
+        expect(executor._unreportedErrors.length).toBe(0);
+
+        executor.push(2).cordon(false);
+        expect(executor.isCordoned).toBe(false);
+        expect(executor._items).toEqual([ 1 ]);
+        expect(executor._activePromise).toBeUndefined();
+        expect(executor._unreportedErrors.length).toBe(1);
+
+        executor.push(2);
+        expect(executor._items).toEqual([ 1, 2 ]);
+        expect(executor._activePromise).toBeUndefined();
+        // it('does not forget the prior Error')
+        expect(executor._unreportedErrors.length).toBe(1);
+
+        await _teardownPipelineSink(executor);
+      });
+    });
+
+    describe('#pushAll', () => {
+      it('triggers an execution once batchSize is reached', async () => {
+        const { executor } = _setupPipelineSink({ batchSize: 5 });
+
+        executor.pushAll([ 1, 2 ]).pushAll([ 3, 4 ]);
+        expect(executor._items).toEqual([ 1, 2, 3, 4 ]);
+        expect(executor._activePromise).toBeUndefined();
+
+        executor.pushAll([ 5 ]);
+        expect(executor._activePromise).not.toBeUndefined();
+
+        expect(executor._unreportedErrors.length).toBe(0);
+        await _teardownPipelineSink(executor);
+      });
+
+      it('will not push when the Executor is cordoned off', async () => {
+        const { executor } = _setupPipelineSink({ batchSize: 5 });
+
+        executor.pushAll([ 1, 2 ]).cordon(true);
+        expect(executor.isCordoned).toBe(true);
+        expect(executor._items).toEqual([ 1, 2 ]);
+        expect(executor._activePromise).toBeUndefined();
+        expect(executor._unreportedErrors.length).toBe(0);
+
+        executor.pushAll([ 3, 4 ]).cordon(false);
+        expect(executor.isCordoned).toBe(false);
+        expect(executor._items).toEqual([ 1, 2 ]);
+        expect(executor._activePromise).toBeUndefined();
+        expect(executor._unreportedErrors.length).toBe(1);
+
+        executor.pushAll([ 3, 4 ]);
+        expect(executor._items).toEqual([ 1, 2, 3, 4 ]);
+        expect(executor._activePromise).toBeUndefined();
+        // it('does not forget the prior Error')
+        expect(executor._unreportedErrors.length).toBe(1);
+
+        await _teardownPipelineSink(executor);
+      });
+    });
+
+
+    describe('#_handleError', () => {
+      it('is thoroughly covered by everything else',  noop);
+    });
+
+    describe('#cordon', () => {
+      it('is covered by #_enforceCordoning',  noop);
+    });
+
+    describe('#_enforceCordoning', () => {
+      const ITEMS = [ 1 ];
+
+      it('does nothing unless the instance is cordoned off', () => {
+        const { executor } = _setupPipelineSink();
+        expect(executor.isCordoned).toBe(false);
+
+        expect(executor._enforceCordoning(ITEMS)).toBe(false);
+        expect(executor._unreportedErrors.length).toBe(0);
+      });
+
+      it('queues up an Error when cordoned off', () => {
+        const { executor } = _setupPipelineSink();
+
+        expect(executor.cordon(true)._enforceCordoning(ITEMS)).toBe(true);
+        expect(executor.isCordoned).toBe(true);
+        expect(executor._unreportedErrors.length).toBe(1);
+
+        const [ error ] = executor._unreportedErrors;
+        expect(error.message).toMatch(/rejected new items/);
+
+        // it('does not forget the prior Error')
+        expect(executor._enforceCordoning(ITEMS)).toBe(true);
+        expect(executor._unreportedErrors.length).toBe(2);
+        expect(executor._unreportedErrors[0]).toBe(error);
+
+        // it('does not abandon the prior Error once uncordoned')
+        //   eg. you cannot simply undo the past
+        expect(executor.cordon(false)._enforceCordoning(ITEMS)).toBe(false);
+        expect(executor._unreportedErrors.length).toBe(2);
+      });
+
+      it('notifies the callback of an Error when cordoned off', () => {
+        const onError = sandbox.spy();
+        const { executor } = _setupPipelineSink({
+          onError
+        });
+
+        expect(executor.cordon(true)._enforceCordoning(ITEMS)).toBe(true);
+        // it('assumes that it has handled the Error')
+        expect(executor._unreportedErrors.length).toBe(0);
+
+        expect(onError.callCount).toBe(1);
+        expect(onError.args[0][0].message).toMatch(/rejected new items/);
+        expect(onError.args[0][1]).toBe(ITEMS);
+      });
+    });
+
+
+    describe('#_executeOnPressure', () => {
+      it('triggers an execution once batchSize is reached', async () => {
+        const { executor } = _setupPipelineSink({ batchSize: 3 });
+
+        expect(executor._executeOnPressure()).toBe(false);
+        expect(executor._activePromise).toBeUndefined();
+
+        expect(executor.pushAll([ 1, 2 ])._executeOnPressure()).toBe(false);
+
+        // pushing would release the pressure, so ...
+        executor._items.push(3);
+        expect(executor._executeOnPressure()).toBe(true);
+        expect(executor._activePromise).not.toBeUndefined();
+
+        await _teardownPipelineSink(executor);
+      });
+    });
+
+    describe('#_executeNextBatch', () => {
+      let executor: BatchPipelineExecutor<number>;
+      let sink: number[];
+      let operationSpy: SinonSpy;
+
+      beforeEach(() => {
+        const setup = _setupPipelineSink<number>({
+          batchSize: 3,
+          poisonItem: POISON,
+        });
+        executor = setup.executor;
+        sink = setup.sink;
+        operationSpy = setup.operationSpy;
+      });
+      afterEach(async () => {
+        await _teardownPipelineSink(executor);
+      });
+
+      it('does nothing without any items', async () => {
+        expect(executor._items.length).toBe(0);
+
+        executor._executeNextBatch();
+        expect(executor._activePromise).toBeUndefined();
+        expect(operationSpy.callCount).toBe(0);
+      });
+
+      it('executes the next batch of items', async () => {
+        // avoid #push operations, since they act under pressure
+        executor._items = [ 1, 2, 3, 4 ];
+        expect(executor._activePromise).toBeUndefined();
+
+        executor._executeNextBatch();
+        expect(executor._activePromise).not.toBeUndefined();
+        expect(executor._items).toEqual([ 4 ]);
+        // it('has started an operation')
+        expect(operationSpy.callCount).toBe(1);
+
+        // it('will not take on a new batch until the current one has finished')
+        executor.pushAll([ 5, 6, 7 ])._executeNextBatch();
+        expect(executor._items).toEqual([ 4, 5, 6, 7 ]);
+        expect(sink).toEqual([]);
+        expect(operationSpy.callCount).toBe(1);
+
+        // it('will ultimately execute all batches')
+        //   including a partial batch
+        await _allowExecution();
+        expect(executor._activePromise).toBeUndefined();
+        expect(executor._items).toEqual([ ]);
+        expect(sink).toEqual([ 1, 2, 3, 4, 5, 6, 7 ]);
+        expect(operationSpy.callCount).toBe(3);
+
+        expect(executor._unreportedErrors.length).toBe(0);
+      });
+
+      it('retries failed work', async () => {
+        // avoid #push operations, since they act under pressure
+        executor._items = [ 1, 2, POISON, 4 ];
+        expect(executor._activePromise).toBeUndefined();
+
+        executor._executeNextBatch();
+        expect(executor._activePromise).not.toBeUndefined();
+        expect(executor._items).toEqual([ 4 ]);
+        expect(sink).toEqual([]);
+        expect(operationSpy.callCount).toBe(1);
+
+        // it('restores the failed items to the batch')
+        await _allowExecution();
+        expect(executor._activePromise).toBeUndefined();
+        expect(executor._items).toEqual([ 1, 2, POISON, 4 ]);
+        expect(executor._unreportedErrors.length).toBe(1);
+        expect(sink).toEqual([]);
+        expect(operationSpy.callCount).toBe(1);
+
+        const [ error ] = executor._unreportedErrors;
+        expect(error.message).toMatch(/POISON/);
+
+        // it('gets the same results a second time')
+        executor._executeNextBatch();
+        await _allowExecution();
+        expect(executor._items).toEqual([ 1, 2, POISON, 4 ]);
+        expect(executor._unreportedErrors.length).toBe(2);
+        expect(operationSpy.callCount).toBe(2);
+
+        // it('does fine once the poison is removed')
+        executor._items[2] = 3;
+        executor._executeNextBatch();
+        await _allowExecution();
+        expect(executor._activePromise).toBeUndefined();
+        expect(executor._items).toEqual([]);
+        expect(executor._unreportedErrors.length).toBe(2);
+        expect(sink).toEqual([ 1, 2, 3, 4 ]);
+        expect(operationSpy.callCount).toBe(4);
+      });
+
+      it('notifies the callback of an Error', async () => {
+        // not the usual setup
+        const onError = sandbox.spy();
+        const setup = _setupPipelineSink<number>({
+          batchSize: 3,
+          poisonItem: POISON,
+          onError,
+        });
+        executor = setup.executor; // for `afterEach` purposes
+
+        // avoid #push operations, since they act under pressure
+        executor._items = [ 1, 2, POISON, 4 ];
+
+        executor._executeNextBatch();
+        await _allowExecution();
+        // it('does not attempt a retry')
+        expect(executor._items).toEqual([ 4 ]);
+        expect(sink).toEqual([]);
+        // it('assumes that it has handled the Error')
+        expect(executor._unreportedErrors.length).toBe(0);
+
+        expect(onError.callCount).toBe(1);
+        expect(onError.args[0][0].message).toMatch(/POISON/);
+        expect(onError.args[0][1]).toEqual([ 1, 2, POISON ]);
+      });
+    });
+
+    describe('#isFlushed', () => {
+      let executor: BatchPipelineExecutor<number>;
+
+      beforeEach(() => {
+        const setup = _setupPipelineSink<number>({
+          poisonItem: POISON,
+        });
+        executor = setup.executor;
+
+        expect(executor.isFlushed).toBe(true);
+      });
+      afterEach(async () => {
+        // it('is flushable by the end of each Test Case')
+        await executor.flush();
+        expect(executor.isFlushed).toBe(true);
+      });
+
+      it('requires no unprocessed items', async () => {
+        executor.push(1);
+        expect(executor._items.length).toBe(1);
+        expect(executor._activePromise).toBeUndefined();
+        expect(executor._unreportedErrors.length).toBe(0);
+
+        expect(executor.isFlushed).toBe(false);
+      });
+
+      it('requires no batches to be in-flight', async () => {
+        executor.push(1);
+        executor._executeNextBatch();
+
+        expect(executor._items.length).toBe(0);
+        expect(executor._activePromise).not.toBeUndefined();
+        expect(executor._unreportedErrors.length).toBe(0);
+
+        expect(executor.isFlushed).toBe(false);
+      });
+
+      it('requires no batches to be in-flight', async () => {
+        executor.push(POISON);
+        executor._executeNextBatch();
+        await _allowExecution();
+        executor._items.shift();
+
+        expect(executor._items.length).toBe(0);
+        expect(executor._activePromise).toBeUndefined();
+        expect(executor._unreportedErrors.length).toBe(1);
+
+        expect(executor.isFlushed).toBe(false);
+
+        // demonstrating what needs to be corrected before it can be flushed
+        executor._unreportedErrors.shift();
+      });
+    });
+
+    describe('#flush', () => {
+      let executor: BatchPipelineExecutor<number>;
+      let sink: number[];
+
+      beforeEach(() => {
+        const setup = _setupPipelineSink<number>({
+          batchSize: 3,
+          poisonItem: POISON,
+        });
+        executor = setup.executor;
+        sink = setup.sink;
+
+        expect(executor.isFlushed).toBe(true);
+      });
+      afterEach(async () => {
+        expect(executor.isFlushed).toBe(true);
+      });
+
+      it('kicks off a batch', async () => {
+        executor.push(1);
+        expect(executor._activePromise).toBeUndefined();
+
+        await executor.flush();
+        expect(sink).toEqual([ 1 ]);
+      });
+
+      it('continues an existing batch', async () => {
+        executor.pushAll([ 1, 2, 3 ]);
+        expect(executor._activePromise).not.toBeUndefined();
+
+        await executor.flush();
+        expect(sink).toEqual([ 1, 2, 3 ]);
+      });
+
+      describe('without an onError callback', () => {
+        it('rejects due to cordoning', async () => {
+          executor.pushAll([ 1, 2, 3, 4 ]).cordon(true).push(5);
+
+          await expect( executor.flush() ).rejects.toThrow(/rejected new items/);
+          expect(sink).toEqual([ 1, 2, 3 ]);
+
+          await executor.flush()
+          expect(sink).toEqual([ 1, 2, 3, 4 ]);
+        });
+
+        it('rejects due to poison', async () => {
+          executor.pushAll([ 1, 2, POISON, 4, POISON, 6 ]);
+
+          // it('needs an antidote')
+          await expect( executor.flush() ).rejects.toThrow(/POISON/);
+          await expect( executor.flush() ).rejects.toThrow(/POISON/);
+          await expect( executor.flush() ).rejects.toThrow(/POISON/);
+          expect(executor._items).toEqual([ 1, 2, POISON, 4, POISON, 6 ]);
+          expect(sink).toEqual([]);
+
+          // it('is not out of the woods yet')
+          executor._items[2] = 3;
+          await expect( executor.flush() ).rejects.toThrow(/POISON/);
+          expect(sink).toEqual([ 1, 2, 3 ]);
+
+          executor._items[1] = 5;
+          await executor.flush()
+          expect(sink).toEqual([ 1, 2, 3, 4, 5, 6 ]);
+        });
+
+        it('has a really bad day', async () => {
+          executor.pushAll([ 1, 2, 3, 4, POISON ]).cordon(true).push(6);
+
+          await expect( executor.flush() ).rejects.toThrow(/rejected new items/);
+          await expect( executor.flush() ).rejects.toThrow(/POISON/);
+          executor._items[1] = 5;
+
+          await executor.flush()
+          expect(sink).toEqual([ 1, 2, 3, 4, 5 ]);
+        });
+      });
+
+      describe('with an onError callback', () => {
+        let onError: SinonSpy;
+
+        beforeEach(() => {
+          // not the usual setup
+          onError = sandbox.spy();
+          const setup = _setupPipelineSink<number>({
+            batchSize: 3,
+            poisonItem: POISON,
+            onError,
+          });
+          executor = setup.executor;
+          sink = setup.sink;
+
+          expect(executor.isFlushed).toBe(true);
+        });
+
+        it('notifies of Errors due to cordoning', async () => {
+          executor.pushAll([ 1, 2, 3, 4 ]).cordon(true).push(5);
+
+          await executor.flush()
+          expect(sink).toEqual([ 1, 2, 3, 4 ]);
+
+          expect(onError.callCount).toBe(1);
+          expect(onError.args[0][0].message).toMatch(/rejected new items/);
+          expect(onError.args[0][1]).toEqual([ 5 ]);
+        });
+
+        it('notifies of Errors due to poison', async () => {
+          executor.pushAll([ 1, 2, POISON, 4, POISON, 6 ]);
+
+          await executor.flush()
+          expect(sink).toEqual([]);
+
+          expect(onError.callCount).toBe(2);
+          expect(onError.args[0][0].message).toMatch(/POISON/);
+          expect(onError.args[0][1]).toEqual([ 1, 2, POISON ]);
+          expect(onError.args[1][0].message).toMatch(/POISON/);
+          expect(onError.args[1][1]).toEqual([ 4, POISON, 6 ]);
+        });
+
+        it('has a really bad day', async () => {
+          executor.pushAll([ 1, 2, 3, 4, POISON ]).cordon(true).push(6);
+
+          await executor.flush()
+          expect(sink).toEqual([ 1, 2, 3 ]);
+
+          expect(onError.callCount).toBe(2);
+          expect(onError.args[0][0].message).toMatch(/rejected new items/);
+          expect(onError.args[0][1]).toEqual([ 6 ]);
+          expect(onError.args[1][0].message).toMatch(/POISON/);
+          expect(onError.args[1][1]).toEqual([ 4, POISON ]);
+        });
+      });
+    });
+  });
+
+});

--- a/src/utils/execution/batch.spec.ts
+++ b/src/utils/execution/batch.spec.ts
@@ -6,7 +6,7 @@ import {
   BatchPipelineExecutor,
   BatchPipelineExecutorOptions,
   executeOperationsInBatches,
-} from './execute';
+} from './batch';
 
 
 const sandbox = createSandbox();
@@ -54,7 +54,7 @@ async function _teardownPipelineSink<T>(executor: BatchPipelineExecutor<T>) {
 }
 
 
-describe("Paginator", () => {
+describe('utils/execution/batch', () => {
   afterEach(() => {
     sandbox.verifyAndRestore();
   });

--- a/src/utils/execution/batch.ts
+++ b/src/utils/execution/batch.ts
@@ -1,0 +1,171 @@
+export type BatchPipelineOperation<T> = (items: T[]) => Promise<void>;
+
+export type BatchPipelineExecutorOptionsStrict<T> = {
+  batchSize: number;
+  // when provided, it is notified upon every Error as it occurs;
+  //   if omitted, all Errors are queued up
+  //   and will be sequentially rejected during #flush
+  onError?(error: Error, items: T[]): void;
+};
+const DEFAULT_OPTIONS: BatchPipelineExecutorOptionsStrict<any> = {
+  batchSize: 8,
+  onError: undefined, // for a simpler Test Suite
+};
+export type BatchPipelineExecutorOptions<T> = Partial<BatchPipelineExecutorOptionsStrict<T>>
+
+
+export class BatchPipelineExecutor<T> {
+  public isCordoned: boolean = false;
+
+  readonly _options: BatchPipelineExecutorOptionsStrict<T>;
+  readonly _unreportedErrors: Error[] = [];
+  public _items: T[] = [];
+  public _activePromise: Promise<void> | undefined = undefined;
+
+  constructor(
+    readonly operation: BatchPipelineOperation<T>,
+    options?: BatchPipelineExecutorOptions<T>
+  ) {
+    this._options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  push(item: T): this {
+    if (this._enforceCordoning([ item ])) {
+      return this;
+    }
+    this._items.push(item);
+    this._executeOnPressure();
+    return this;
+  }
+
+  pushAll(items: T[]): this {
+    if (this._enforceCordoning(items)) {
+      return this;
+    }
+    this._items = this._items.concat(items);
+    this._executeOnPressure();
+    return this;
+  }
+
+
+  _handleError(error: Error, items: T[]): void {
+    const { onError } = this._options;
+    if (onError) {
+      // callback immediately
+      onError(error, items);
+    }
+    else {
+      // queue for later reporting;
+      //   important for avoiding `UnhandledRejection`s
+      this._unreportedErrors.push(error);
+    }
+  }
+
+  _enforceCordoning(items: T[]): boolean {
+    if (! this.isCordoned) {
+      return false;
+    }
+
+    this._handleError(
+      new Error('BatchPipelineExecutor#_enforceCordoning: rejected new items'),
+      items
+    );
+    return true;
+  }
+
+  cordon(state: boolean): this {
+    this.isCordoned = state;
+    return this;
+  }
+
+
+  _executeOnPressure(): boolean {
+    const { _items, _options } = this;
+    if (_items.length < _options.batchSize) {
+      return false;
+    }
+
+    this._executeNextBatch();
+    return true;
+  }
+
+  _executeNextBatch(): void {
+    const { operation, _options, _items, _activePromise } = this;
+    const { batchSize, onError } = _options;
+    if (_items.length === 0) {
+      return;
+    }
+    if (_activePromise) {
+      // we will get around to that
+      return;
+    }
+
+    // this will mutate the _items in place
+    const batch = _items.splice(0, batchSize);
+    const batchPromise = new Promise<void>((resolve) => {
+      operation(batch)
+      .then(() => {
+        // onto the next batch
+        this._activePromise = undefined;
+        this._executeNextBatch();
+
+        resolve();
+      })
+      .catch((error) => {
+        this._activePromise = undefined;
+
+        if (! onError) {
+          // restore the entire batch for later retry;
+          //   the onError handler is not expected to correct the problem,
+          //   so retry would simply become a death loop
+          this._items = batch.concat(this._items);
+        }
+
+        this._handleError(error, batch);
+        resolve();
+      });
+    });
+
+    this._activePromise = batchPromise;
+  }
+
+
+  get isFlushed(): boolean {
+    return (
+      (this._items.length === 0) &&
+      (! this._activePromise) && // nothing in flight
+      (this._unreportedErrors.length === 0) // nothing we need to report
+    );
+  }
+
+  async flush(): Promise<void> {
+    const { _unreportedErrors } = this;
+
+    // bail as soon as things go badly
+    while (_unreportedErrors.length === 0) {
+      // kick off all remaining batches
+      this._executeNextBatch();
+      if (! this._activePromise) {
+        break;
+      }
+      await this._activePromise;
+    }
+
+    const error = _unreportedErrors.shift();
+    if (error) {
+      throw error;
+    }
+
+    // we are flushed!
+  }
+}
+
+
+export async function executeOperationsInBatches<T>(
+  items: T[],
+  operation: BatchPipelineOperation<T>,
+  options?: BatchPipelineExecutorOptions<T>
+): Promise<void> {
+  const executor = new BatchPipelineExecutor(operation, options);
+  return executor.pushAll(items).flush();
+}

--- a/src/utils/execution/parallel.spec.ts
+++ b/src/utils/execution/parallel.spec.ts
@@ -1,28 +1,11 @@
 import uuidV4 from 'uuid/v4';
 
 import {
-  NULL_STRING,
-  isUUID,
   executeOperationsInParallel,
-} from './miscellaneous';
+} from './parallel';
 
 
-describe('utils/miscellaneous', () => {
-  describe('isUUID', () => {
-    it('detects a UUID', () => {
-      const UUID = uuidV4();
-
-      expect(isUUID(UUID)).toBe(true);
-    });
-
-    it('does not recognize a non-UUID', () => {
-      expect(isUUID('')).toBe(false);
-      expect(isUUID(NULL_STRING)).toBe(false);
-      expect(isUUID(<unknown>undefined as string)).toBe(false);
-    });
-  });
-
-
+describe('utils/execution/parallel', () => {
   describe('executeOperationsInParallel', () => {
     // a bunch of arbitrary items
     const ITEM_COUNT = 20;

--- a/src/utils/execution/parallel.spec.ts
+++ b/src/utils/execution/parallel.spec.ts
@@ -1,0 +1,118 @@
+import uuidV4 from 'uuid/v4';
+
+import {
+  NULL_STRING,
+  isUUID,
+  executeOperationsInParallel,
+} from './miscellaneous';
+
+
+describe('utils/miscellaneous', () => {
+  describe('isUUID', () => {
+    it('detects a UUID', () => {
+      const UUID = uuidV4();
+
+      expect(isUUID(UUID)).toBe(true);
+    });
+
+    it('does not recognize a non-UUID', () => {
+      expect(isUUID('')).toBe(false);
+      expect(isUUID(NULL_STRING)).toBe(false);
+      expect(isUUID(<unknown>undefined as string)).toBe(false);
+    });
+  });
+
+
+  describe('executeOperationsInParallel', () => {
+    // a bunch of arbitrary items
+    const ITEM_COUNT = 20;
+    const ITEMS = (new Array<number>( ITEM_COUNT )).fill(0).map((_, index) => index);
+
+    it('executes Model in parallel', async () => {
+      const visitedItems: number[] = [];
+
+      const models = await executeOperationsInParallel(ITEMS, async (item) => {
+        visitedItems.push(item);
+        return item;
+      });
+
+      // it('resolves them all, in order')
+      expect(models).toEqual(ITEMS);
+
+      // it('visited them all, in order')
+      expect(visitedItems).toEqual(ITEMS);
+    });
+
+    it('fails if an item in the first batch fails', async () => {
+      await expect(
+        executeOperationsInParallel(ITEMS, async (item) => {
+          if (item === 2) {
+            throw new Error('BOOM');
+          }
+        }, { batchSize: 3 })
+      ).rejects.toThrow('BOOM');
+    });
+
+    it('fails if an item in a secondary batch fails', async () => {
+      await expect(
+        executeOperationsInParallel(ITEMS, async (item) => {
+          if (item === 4) {
+            throw new Error('BOOM');
+          }
+        }, { batchSize: 3 })
+      ).rejects.toThrow('BOOM');
+    });
+
+    it('allows a parallelization batch size to be specified', async () => {
+      const INTERVAL = 100; // ms; enough to be "precise"
+      const nowAtStart = Date.now();
+      const stamps: number[] = [];
+      const iteratorIndexes: number[] = [];
+      let iteratorItems: Array<number> = [];
+
+      await executeOperationsInParallel(ITEMS, async (item, index, items) => {
+        stamps.push(Date.now() - nowAtStart);
+        iteratorIndexes.push(index);
+        iteratorItems = items;
+
+        // a time lag, to differentiate the batches;
+        //   batch N Promises will all resolve "at the same time"
+        //   batch (N + 1) won't start until batch N has fully resolved
+        return new Promise((resolve) => setTimeout(resolve, INTERVAL));
+      }, { batchSize: 6 });
+
+      // it('imposed the specified batch size')
+      expect(
+        stamps.map((t) => Math.floor(t / INTERVAL))
+      ).toEqual([
+        0, 0, 0, 0, 0, 0,
+        1, 1, 1, 1, 1, 1,
+        2, 2, 2, 2, 2, 2,
+        3, 3,
+      ]);
+
+      // it('provides iterator arguments')
+      expect(iteratorIndexes).toEqual([
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ]);
+      expect(iteratorItems).toBe(ITEMS);
+    });
+
+    it('Executes efficiently', async () => {
+      const timeoutPromise = (sideEffect: (ms: number) => void) => (ms: number) =>
+        new Promise((res) => setTimeout(res, ms, ms))
+          .then(((ms: number) => sideEffect(ms)) as any)
+      const evidence: number[] = [];
+      const times = [1, 1000, 2, 3];
+      await executeOperationsInParallel(
+        times,
+        timeoutPromise((ms) => evidence.push(ms)),
+        { batchSize: 2 }
+      );
+      // it("counts to 1000")
+      expect(evidence).toMatchObject([1,2,3,1000]);
+    });
+
+  });
+});

--- a/src/utils/execution/parallel.ts
+++ b/src/utils/execution/parallel.ts
@@ -1,21 +1,12 @@
 import { sortBy, identity } from 'lodash';
 
 
-// to save us from TypeScript side-effects of nullable properties that aren't `| null`
-export const NULL_STRING = (<unknown>null as string);
+export type ParallelOperation<T, U> = (item: T, index: number, array: T[]) => Promise<U>;
 
-
-const UUID_REGEXP: RegExp = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-
-export function isUUID(id: string): boolean {
-  return ((!! id) && UUID_REGEXP.test(id));
-}
-
-
-export interface IExecuteOperationsInParallelOptions {
+export type ParallelExecutorOptions = {
   batchSize?: number;
 }
-const EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS: Required<IExecuteOperationsInParallelOptions> = {
+const EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS: Required<ParallelExecutorOptions> = {
   batchSize: 8,
 };
 
@@ -36,8 +27,8 @@ const EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS: Required<IExecuteOperations
 */
 export async function executeOperationsInParallel<T = any, U = any>(
   items: T[],
-  operation: (item: T, index: number, array: T[]) => Promise<U>,
-  options?: IExecuteOperationsInParallelOptions
+  operation: ParallelOperation<T, U>,
+  options?: ParallelExecutorOptions
 ): Promise<U[]> {
   // begin with a wall of `batchSize` promises
   const batchSize = options?.batchSize || EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS.batchSize;

--- a/src/utils/execution/parallel.ts
+++ b/src/utils/execution/parallel.ts
@@ -1,0 +1,75 @@
+import { sortBy, identity } from 'lodash';
+
+
+// to save us from TypeScript side-effects of nullable properties that aren't `| null`
+export const NULL_STRING = (<unknown>null as string);
+
+
+const UUID_REGEXP: RegExp = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export function isUUID(id: string): boolean {
+  return ((!! id) && UUID_REGEXP.test(id));
+}
+
+
+export interface IExecuteOperationsInParallelOptions {
+  batchSize?: number;
+}
+const EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS: Required<IExecuteOperationsInParallelOptions> = {
+  batchSize: 8,
+};
+
+/*
+  Caution: this function does not eat errors,
+  it puts the onus on the user. The whole process will fail on ONE error
+  We want each promise to either
+    * spawn a new promise or
+    * terminate.
+  Eg for batchSize = 4 we will do something like:
+    () => () => null
+    () => () => () => null
+    () => null
+    () => () => null
+  Where each () represents a unit of work.
+  Finally, because we don't know what will finish when,
+  we need to store results in a map and sort it out at the end.
+*/
+export async function executeOperationsInParallel<T = any, U = any>(
+  items: T[],
+  operation: (item: T, index: number, array: T[]) => Promise<U>,
+  options?: IExecuteOperationsInParallelOptions
+): Promise<U[]> {
+  // begin with a wall of `batchSize` promises
+  const batchSize = options?.batchSize || EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS.batchSize;
+  const initialBatch = items.slice(0, batchSize);
+
+  // when a promise finishes it will:
+  // * store a result
+  // * pull from the queue
+  // * increment the index
+  let workQueue = items.slice(batchSize);
+  let currentIndex = batchSize;
+  let results: Map<number, U> = new Map();
+
+  // A recursion in two parts,
+  // each function will call the other after each promise
+  // until `storeAndTryNext` terminates the process by returning `null`
+
+  // represents a unit of work
+  const work = (item: T, index: number) => operation(item, index, items)
+        .then(nextResult => storeAndTryNext(nextResult, index))
+
+  // * store the indexed result
+  // * if we're out of work end the chain by returning null
+  // * otherwise recurse on work()
+  const storeAndTryNext = (result: U, index: number): Promise<U | null> | null => {
+    results.set(index, result);
+    if(workQueue.length === 0) { return null; }
+    return work(workQueue.shift()!, currentIndex++);
+  }
+  // start the promise wall and wait for it to finish
+  let promiseGroup = initialBatch.map((item, index) => work(item, index));
+  await Promise.all(promiseGroup);
+  return sortBy(Array.from(results.keys()), identity)
+    .map((key:number) => results.get(key) as U);
+}

--- a/src/utils/miscellaneous.spec.ts
+++ b/src/utils/miscellaneous.spec.ts
@@ -3,7 +3,6 @@ import uuidV4 from 'uuid/v4';
 import {
   NULL_STRING,
   isUUID,
-  executeOperationsInParallel,
 } from './miscellaneous';
 
 
@@ -20,99 +19,5 @@ describe('utils/miscellaneous', () => {
       expect(isUUID(NULL_STRING)).toBe(false);
       expect(isUUID(<unknown>undefined as string)).toBe(false);
     });
-  });
-
-
-  describe('executeOperationsInParallel', () => {
-    // a bunch of arbitrary items
-    const ITEM_COUNT = 20;
-    const ITEMS = (new Array<number>( ITEM_COUNT )).fill(0).map((_, index) => index);
-
-    it('executes Model in parallel', async () => {
-      const visitedItems: number[] = [];
-
-      const models = await executeOperationsInParallel(ITEMS, async (item) => {
-        visitedItems.push(item);
-        return item;
-      });
-
-      // it('resolves them all, in order')
-      expect(models).toEqual(ITEMS);
-
-      // it('visited them all, in order')
-      expect(visitedItems).toEqual(ITEMS);
-    });
-
-    it('fails if an item in the first batch fails', async () => {
-      await expect(
-        executeOperationsInParallel(ITEMS, async (item) => {
-          if (item === 2) {
-            throw new Error('BOOM');
-          }
-        }, { batchSize: 3 })
-      ).rejects.toThrow('BOOM');
-    });
-
-    it('fails if an item in a secondary batch fails', async () => {
-      await expect(
-        executeOperationsInParallel(ITEMS, async (item) => {
-          if (item === 4) {
-            throw new Error('BOOM');
-          }
-        }, { batchSize: 3 })
-      ).rejects.toThrow('BOOM');
-    });
-
-    it('allows a parallelization batch size to be specified', async () => {
-      const INTERVAL = 100; // ms; enough to be "precise"
-      const nowAtStart = Date.now();
-      const stamps: number[] = [];
-      const iteratorIndexes: number[] = [];
-      let iteratorItems: Array<number> = [];
-
-      await executeOperationsInParallel(ITEMS, async (item, index, items) => {
-        stamps.push(Date.now() - nowAtStart);
-        iteratorIndexes.push(index);
-        iteratorItems = items;
-
-        // a time lag, to differentiate the batches;
-        //   batch N Promises will all resolve "at the same time"
-        //   batch (N + 1) won't start until batch N has fully resolved
-        return new Promise((resolve) => setTimeout(resolve, INTERVAL));
-      }, { batchSize: 6 });
-
-      // it('imposed the specified batch size')
-      expect(
-        stamps.map((t) => Math.floor(t / INTERVAL))
-      ).toEqual([
-        0, 0, 0, 0, 0, 0,
-        1, 1, 1, 1, 1, 1,
-        2, 2, 2, 2, 2, 2,
-        3, 3,
-      ]);
-
-      // it('provides iterator arguments')
-      expect(iteratorIndexes).toEqual([
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-      ]);
-      expect(iteratorItems).toBe(ITEMS);
-    });
-
-    it('Executes efficiently', async () => {
-      const timeoutPromise = (sideEffect: (ms: number) => void) => (ms: number) =>
-        new Promise((res) => setTimeout(res, ms, ms))
-          .then(((ms: number) => sideEffect(ms)) as any)
-      const evidence: number[] = [];
-      const times = [1, 1000, 2, 3];
-      await executeOperationsInParallel(
-        times,
-        timeoutPromise((ms) => evidence.push(ms)),
-        { batchSize: 2 }
-      );
-      // it("counts to 1000")
-      expect(evidence).toMatchObject([1,2,3,1000]);
-    });
-
   });
 });

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -1,6 +1,3 @@
-import { sortBy, identity } from 'lodash';
-
-
 // to save us from TypeScript side-effects of nullable properties that aren't `| null`
 export const NULL_STRING = (<unknown>null as string);
 
@@ -9,67 +6,4 @@ const UUID_REGEXP: RegExp = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0
 
 export function isUUID(id: string): boolean {
   return ((!! id) && UUID_REGEXP.test(id));
-}
-
-
-export interface IExecuteOperationsInParallelOptions {
-  batchSize?: number;
-}
-const EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS: Required<IExecuteOperationsInParallelOptions> = {
-  batchSize: 8,
-};
-
-/*
-  Caution: this function does not eat errors,
-  it puts the onus on the user. The whole process will fail on ONE error
-  We want each promise to either
-    * spawn a new promise or
-    * terminate.
-  Eg for batchSize = 4 we will do something like:
-    () => () => null
-    () => () => () => null
-    () => null
-    () => () => null
-  Where each () represents a unit of work.
-  Finally, because we don't know what will finish when,
-  we need to store results in a map and sort it out at the end.
-*/
-export async function executeOperationsInParallel<T = any, U = any>(
-  items: T[],
-  operation: (item: T, index: number, array: T[]) => Promise<U>,
-  options?: IExecuteOperationsInParallelOptions
-): Promise<U[]> {
-  // begin with a wall of `batchSize` promises
-  const batchSize = options?.batchSize || EXECUTE_MODEL_OPERATIONS_IN_PARALLEL_DEFAULTS.batchSize;
-  const initialBatch = items.slice(0, batchSize);
-
-  // when a promise finishes it will:
-  // * store a result
-  // * pull from the queue
-  // * increment the index
-  let workQueue = items.slice(batchSize);
-  let currentIndex = batchSize;
-  let results: Map<number, U> = new Map();
-
-  // A recursion in two parts,
-  // each function will call the other after each promise
-  // until `storeAndTryNext` terminates the process by returning `null`
-
-  // represents a unit of work
-  const work = (item: T, index: number) => operation(item, index, items)
-        .then(nextResult => storeAndTryNext(nextResult, index))
-
-  // * store the indexed result
-  // * if we're out of work end the chain by returning null
-  // * otherwise recurse on work()
-  const storeAndTryNext = (result: U, index: number): Promise<U | null> | null => {
-    results.set(index, result);
-    if(workQueue.length === 0) { return null; }
-    return work(workQueue.shift()!, currentIndex++);
-  }
-  // start the promise wall and wait for it to finish
-  let promiseGroup = initialBatch.map((item, index) => work(item, index));
-  await Promise.all(promiseGroup);
-  return sortBy(Array.from(results.keys()), identity)
-    .map((key:number) => results.get(key) as U);
 }

--- a/src/utils/typeorm/migration.ts
+++ b/src/utils/typeorm/migration.ts
@@ -4,7 +4,7 @@
 import { QueryRunner } from 'typeorm';
 const { prepareValue: pgPrepareValue } = require('pg/lib/utils');
 
-import { executeOperationsInParallel } from '../miscellaneous';
+import { executeOperationsInParallel } from '../execution/parallel';
 
 
 export type MigrationPostgresSettings = Record<string, any> & {


### PR DESCRIPTION
- `executeOperationsInBatches` lives in 'src/utils/execution'
- and `executeOperationsInParallel` lives there now, too
- exporting Parallel-related types (vs. interfaces)
- fixes from PR feedback on https://github.com/joylifeinc/product_service/pull/222
