### PR TITLE
SHOP-112 implement out-of-band HealthCheckers

### DIFF
--- a/src/utils/healthCheck/postgres.ts
+++ b/src/utils/healthCheck/postgres.ts
@@ -10,6 +10,7 @@ import { Context } from '../../server/apollo.context';
 
 export async function healthCheckerPostgres(context: Context): Promise<boolean> {
   const { telemetry } = context;
+  const timeAtStart = Date.now();
 
   try {
     // Posgres should be able to tell us its current time-of-day
@@ -21,11 +22,14 @@ export async function healthCheckerPostgres(context: Context): Promise<boolean> 
     return true;
   }
   catch (error) {
+    const durationMs = Date.now() - timeAtStart; // mostly for timeouts
     telemetry.error('healthCheckerPostgres: failure', {
       ...deriveTelemetryContextFromError(error),
       source: 'healthCheck',
       action: 'postgres',
+      durationMs,
     });
+
     return false;
   }
 }

--- a/src/utils/healthCheck/requestHandler.ts
+++ b/src/utils/healthCheck/requestHandler.ts
@@ -17,6 +17,7 @@ export function createHealthCheckRequestHandler<T extends Context = Context>(
   const successStatusCode = options.successStatusCode || 200;
   const failureStatusCode = options.failureStatusCode || 500;
   const nonCritical = new Set(options.nonCritical || []);
+  const outOfBand = new Set(options.outOfBand || []);
 
   const requestHandler: RequestHandler = async(req: Request, res: Response, next: NextFunction): Promise<void> => {
     const context = deriveContextFromRequest(req) as T;
@@ -28,24 +29,33 @@ export function createHealthCheckRequestHandler<T extends Context = Context>(
     const resultsByKey: Record<string, boolean> = {};
     await Promise.all(Object.keys(checkers).map(async (key) => {
       const checker = checkers[key];
-      try {
-        // don't wait forever;
-        //   if we eventually get a success, we would appear to be healthy to our logs,
-        //   however ... k8s will have given up waiting, and we're actually failed
-        //   and been taken out of the load pool, or out behind the barn.
-        //   we need visiblity into our failure
-        resultsByKey[key] = await executePromiseOrTimeout(timeoutMs, () => checker(context));
-      }
-      catch (error) {
+      const timeAtStart = Date.now();
+
+      // don't wait forever;
+      //   if we eventually get a success, we would appear to be healthy to our logs,
+      //   however ... k8s will have given up waiting, and we're actually failed
+      //   and been taken out of the load pool, or out behind the barn.
+      //   we need visiblity into our failure
+      const promise = executePromiseOrTimeout(timeoutMs, () => checker(context))
+      .catch((error) => {
         // this is *not* expected;
         //   each Health Checker should catch, log and absorb its own Errors
+        const durationMs = Date.now() - timeAtStart; // mostly for timeouts
         context.telemetry.error('requestHandler: failure', {
           ...deriveTelemetryContextFromError(error),
           source: 'healthCheck',
           action: 'requestHandler',
           key,
+          durationMs,
         });
-        resultsByKey[key] = false;
+
+        return false;
+      });
+
+      // out-of-band checks are neither `await`ed nor reported
+      //   but they *do* get executed upon Promise construction
+      if (! outOfBand.has(key)) {
+        resultsByKey[key] = await promise;
       }
     }));
 

--- a/src/utils/healthCheck/typeormMigrations.ts
+++ b/src/utils/healthCheck/typeormMigrations.ts
@@ -13,6 +13,7 @@ import { Context } from '../../server/apollo.context';
 
 export async function healthCheckerTypeormMigrations(context: Context): Promise<boolean> {
   const { telemetry } = context;
+  const timeAtStart = Date.now();
 
   try {
     // officially part of `typeorm`
@@ -38,11 +39,14 @@ export async function healthCheckerTypeormMigrations(context: Context): Promise<
     return true;
   }
   catch (error) {
+    const durationMs = Date.now() - timeAtStart; // mostly for timeouts
     telemetry.error('healthCheckerTypeormMigrations: failure', {
       ...deriveTelemetryContextFromError(error),
       source: 'healthCheck',
       action: 'typeormMigrations',
+      durationMs,
     });
+
     return false;
   }
 }

--- a/src/utils/healthCheck/types.ts
+++ b/src/utils/healthCheck/types.ts
@@ -1,13 +1,14 @@
 import { Context } from '../../server/apollo.context';
 
 // must be less than the following k8s settings
+// as found in 'ops.git:values/deployments/*.yaml'
 // ```yaml
 // readiness:
-//   timeoutSeconds: 3
+//   timeoutSeconds: 5
 // liveness:
-//   timeoutSeconds: 3
+//   timeoutSeconds: 5
 // ```
-export const HEALTH_CHECKER_TIMEOUT_MS = 2500; // 2.5s
+export const HEALTH_CHECKER_TIMEOUT_MS = 4500; // 4.5s
 
 export type HealthPredicate = () => Promise<boolean>;
 export type HealthChecker<T extends Context = Context> = (context: T) => Promise<boolean>;
@@ -16,22 +17,45 @@ export interface HealthCheckProvider<T extends Context = Context> {
 };
 
 export type HealthCheckRequestHandlerOptions<T extends Context = Context> = {
-  // everything that should get checked;
-  //   each HealthChecker is checked independently; any single failure doesn't impact the others.
-  //   the HTTP payload returned by the endpoint will be a `Record<string, boolean>` of the results
+  /**
+   * Everything that should get checked.
+   *
+   * Each HealthChecker is checked independently; any single failure doesn't impact the others.
+   * The HTTP payload returned by the endpoint will be a `Record<string, boolean>` of the results.
+   */
   checkers: Record<string, HealthChecker<T>>;
-  // any HealthChecker not responding will be considered failed
+  /**
+   * Any HealthChecker not responding within this timeframe will be considered failed.
+   */
   timeoutMs?: number;
-  // the HTTP endpoint returns this status code when
-  //   all of the `HealthChecker`s pass / resolve `true`
+  /**
+   * The HTTP endpoint returns this status code when all of the `HealthChecker`s pass / resolve `true`,
+   */
   successStatusCode?: number;
-  // the HTTP endpoint returns this status code when
-  //   any of the `HealthChecker`s fail / throw / resolve `false`.
-  //   you can modify this status code to mask the failure.
-  //   (eg. `200` = run all the checks, output an accurate payload, but don't report a failure status)
-  //   (it's like marking *everything* as `{ nonCritical }`)
+  /**
+   * The HTTP endpoint returns this status code when any of the `HealthChecker`s fail / throw / resolve `false`.
+   *
+   * You could modify this status code to mask the failure,
+   * eg. `200` = run all the checks, output an accurate payload, but don't report an aggregate failure status.
+   * That'd be like marking *everything* as `{ nonCritical }`.
+   */
   failureStatusCode?: number;
-  // keys in `{ checkers }` which are allowed to fail
-  //   the check is run, and it is accurate in the payload, but it doesn't impact aggregate status
+  /**
+   * Keys in `{ checkers }` which are allowed to fail.
+   *
+   * The check is run, and it is accurate in the payload, but it doesn't impact aggregate status.
+   */
   nonCritical?: string[], // <keyof this.checkers>[]
+  /**
+   * Keys in `{ checkers }` which are run out-of-band.
+   *
+   * The check is run asynchronously, and no one waits for it to finish.
+   *
+   * - it does not contribute to the aggregate status, nor the duration, of the health check.
+   * - its result is not included in the aggregate JSON payload of all checks.
+   * - if the check fails, that gets logged independently.
+   *
+   * By its nature, an out-of-band check is also `{ nonCritical }`.
+   */
+  outOfBand?: string[], // <keyof this.checkers>[]
 };

--- a/src/utils/healthCheck/utils.ts
+++ b/src/utils/healthCheck/utils.ts
@@ -17,18 +17,22 @@ export function isHealthCheckRoute(route: string): boolean {
 export function healthCheckForPredicate(healthPredicate: HealthPredicate): HealthChecker {
   return async (context) => {
     const { telemetry } = context;
+    const timeAtStart = Date.now();
 
     try {
       const healthy = await healthPredicate();
       return healthy;
     }
     catch (error) {
+      const durationMs = Date.now() - timeAtStart; // mostly for timeouts
       telemetry.error('healthCheckForPredicate: failure', {
         ...deriveTelemetryContextFromError(error),
         source: 'healthCheck',
         action: 'healthCheckForPredicate',
         predicate: healthPredicate.name,
+        durationMs,
       });
+
       return false;
     }
   };


### PR DESCRIPTION
- it does not contribute to the aggregate status, nor the duration, of the health check.
- its result is not included in the aggregate JSON payload of all checks.
- if the check fails, that gets logged independently.

also,

- re-align HEALTH_CHECKER_TIMEOUT_MS with current k8s configurations
- report { durationMs } in all the useful places
- ~holy shit!~  VSCode shows you Markdown if you use JSDoc style comments!
